### PR TITLE
Require a memory and writeback stage for the CFU plugin.

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/Makefile
+++ b/pythondata_cpu_vexriscv/verilog/Makefile
@@ -27,10 +27,10 @@ VexRiscv_MinDebug.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault -d --iCacheSize 0 --dCacheSize 0 --mulDiv false --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --outputFile VexRiscv_MinDebug"
 
 VexRiscv_Fomu.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --safe false --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --hardwareDiv false --memoryAndWritebackStage false --outputFile VexRiscv_Fomu"
+	sbt compile "runMain vexriscv.GenCoreDefault --safe false --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --hardwareDiv false --outputFile VexRiscv_Fomu"
 
 VexRiscv_FomuCfu.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --safe false --cfu true --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none  --hardwareDiv false --memoryAndWritebackStage false --outputFile VexRiscv_FomuCfu"
+	sbt compile "runMain vexriscv.GenCoreDefault --safe false --cfu true --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none  --hardwareDiv false --outputFile VexRiscv_FomuCfu"
 
 VexRiscv_Full.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all --outputFile VexRiscv_Full"

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.v
@@ -1,6 +1,6 @@
 // Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
-// Git hash  : 301554ed50130998df7c9b3fa2a900ddbefe2027
+// Git hash  : 43e13174d8583db5f4cd45d2b3515bc206a0010a
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -73,18 +73,18 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_119;
-  wire                _zz_120;
-  wire                _zz_121;
-  wire                _zz_122;
-  wire                _zz_123;
-  wire                _zz_124;
-  wire                _zz_125;
-  wire                _zz_126;
-  reg                 _zz_127;
-  reg        [31:0]   _zz_128;
-  reg        [31:0]   _zz_129;
-  reg        [31:0]   _zz_130;
+  wire                _zz_129;
+  wire                _zz_130;
+  wire                _zz_131;
+  wire                _zz_132;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
+  wire                _zz_136;
+  reg                 _zz_137;
+  reg        [31:0]   _zz_138;
+  reg        [31:0]   _zz_139;
+  reg        [31:0]   _zz_140;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -97,16 +97,6 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_131;
-  wire                _zz_132;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
-  wire                _zz_139;
-  wire       [1:0]    _zz_140;
   wire                _zz_141;
   wire                _zz_142;
   wire                _zz_143;
@@ -115,287 +105,357 @@ module VexRiscv (
   wire                _zz_146;
   wire                _zz_147;
   wire                _zz_148;
-  wire                _zz_149;
+  wire       [1:0]    _zz_149;
   wire                _zz_150;
   wire                _zz_151;
   wire                _zz_152;
-  wire       [1:0]    _zz_153;
+  wire                _zz_153;
   wire                _zz_154;
-  wire       [0:0]    _zz_155;
-  wire       [0:0]    _zz_156;
-  wire       [0:0]    _zz_157;
-  wire       [0:0]    _zz_158;
-  wire       [0:0]    _zz_159;
-  wire       [0:0]    _zz_160;
-  wire       [0:0]    _zz_161;
-  wire       [0:0]    _zz_162;
-  wire       [0:0]    _zz_163;
-  wire       [0:0]    _zz_164;
-  wire       [0:0]    _zz_165;
-  wire       [0:0]    _zz_166;
-  wire       [0:0]    _zz_167;
-  wire       [2:0]    _zz_168;
-  wire       [2:0]    _zz_169;
-  wire       [31:0]   _zz_170;
+  wire                _zz_155;
+  wire                _zz_156;
+  wire                _zz_157;
+  wire                _zz_158;
+  wire                _zz_159;
+  wire                _zz_160;
+  wire                _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  wire                _zz_164;
+  wire                _zz_165;
+  wire       [1:0]    _zz_166;
+  wire                _zz_167;
+  wire       [0:0]    _zz_168;
+  wire       [0:0]    _zz_169;
+  wire       [0:0]    _zz_170;
   wire       [0:0]    _zz_171;
-  wire       [2:0]    _zz_172;
-  wire       [4:0]    _zz_173;
-  wire       [11:0]   _zz_174;
-  wire       [11:0]   _zz_175;
-  wire       [31:0]   _zz_176;
-  wire       [31:0]   _zz_177;
-  wire       [31:0]   _zz_178;
-  wire       [31:0]   _zz_179;
-  wire       [31:0]   _zz_180;
-  wire       [31:0]   _zz_181;
-  wire       [31:0]   _zz_182;
-  wire       [31:0]   _zz_183;
-  wire       [32:0]   _zz_184;
-  wire       [19:0]   _zz_185;
-  wire       [11:0]   _zz_186;
-  wire       [11:0]   _zz_187;
-  wire       [1:0]    _zz_188;
-  wire       [1:0]    _zz_189;
-  wire       [0:0]    _zz_190;
-  wire       [5:0]    _zz_191;
-  wire       [33:0]   _zz_192;
-  wire       [32:0]   _zz_193;
-  wire       [33:0]   _zz_194;
-  wire       [32:0]   _zz_195;
-  wire       [33:0]   _zz_196;
-  wire       [32:0]   _zz_197;
-  wire       [0:0]    _zz_198;
+  wire       [0:0]    _zz_172;
+  wire       [0:0]    _zz_173;
+  wire       [0:0]    _zz_174;
+  wire       [0:0]    _zz_175;
+  wire       [0:0]    _zz_176;
+  wire       [0:0]    _zz_177;
+  wire       [0:0]    _zz_178;
+  wire       [0:0]    _zz_179;
+  wire       [0:0]    _zz_180;
+  wire       [0:0]    _zz_181;
+  wire       [0:0]    _zz_182;
+  wire       [2:0]    _zz_183;
+  wire       [2:0]    _zz_184;
+  wire       [31:0]   _zz_185;
+  wire       [0:0]    _zz_186;
+  wire       [2:0]    _zz_187;
+  wire       [4:0]    _zz_188;
+  wire       [11:0]   _zz_189;
+  wire       [11:0]   _zz_190;
+  wire       [31:0]   _zz_191;
+  wire       [31:0]   _zz_192;
+  wire       [31:0]   _zz_193;
+  wire       [31:0]   _zz_194;
+  wire       [31:0]   _zz_195;
+  wire       [31:0]   _zz_196;
+  wire       [31:0]   _zz_197;
+  wire       [31:0]   _zz_198;
   wire       [32:0]   _zz_199;
-  wire       [0:0]    _zz_200;
-  wire       [31:0]   _zz_201;
-  wire       [0:0]    _zz_202;
+  wire       [19:0]   _zz_200;
+  wire       [11:0]   _zz_201;
+  wire       [11:0]   _zz_202;
   wire       [0:0]    _zz_203;
-  wire       [0:0]    _zz_204;
-  wire       [0:0]    _zz_205;
-  wire       [0:0]    _zz_206;
-  wire       [0:0]    _zz_207;
-  wire       [26:0]   _zz_208;
-  wire                _zz_209;
-  wire                _zz_210;
-  wire       [1:0]    _zz_211;
-  wire       [31:0]   _zz_212;
-  wire       [31:0]   _zz_213;
+  wire       [5:0]    _zz_204;
+  wire       [33:0]   _zz_205;
+  wire       [32:0]   _zz_206;
+  wire       [33:0]   _zz_207;
+  wire       [32:0]   _zz_208;
+  wire       [33:0]   _zz_209;
+  wire       [32:0]   _zz_210;
+  wire       [0:0]    _zz_211;
+  wire       [32:0]   _zz_212;
+  wire       [0:0]    _zz_213;
   wire       [31:0]   _zz_214;
-  wire                _zz_215;
+  wire       [0:0]    _zz_215;
   wire       [0:0]    _zz_216;
-  wire       [13:0]   _zz_217;
-  wire       [31:0]   _zz_218;
-  wire       [31:0]   _zz_219;
-  wire       [31:0]   _zz_220;
-  wire                _zz_221;
-  wire       [0:0]    _zz_222;
-  wire       [7:0]    _zz_223;
-  wire       [31:0]   _zz_224;
+  wire       [0:0]    _zz_217;
+  wire       [0:0]    _zz_218;
+  wire       [0:0]    _zz_219;
+  wire       [0:0]    _zz_220;
+  wire       [26:0]   _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire       [1:0]    _zz_224;
   wire       [31:0]   _zz_225;
   wire       [31:0]   _zz_226;
-  wire                _zz_227;
-  wire       [0:0]    _zz_228;
-  wire       [1:0]    _zz_229;
-  wire                _zz_230;
-  wire       [0:0]    _zz_231;
-  wire       [0:0]    _zz_232;
-  wire                _zz_233;
-  wire       [0:0]    _zz_234;
-  wire       [23:0]   _zz_235;
-  wire       [31:0]   _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire       [0:0]    _zz_239;
-  wire       [0:0]    _zz_240;
+  wire       [31:0]   _zz_227;
+  wire                _zz_228;
+  wire       [0:0]    _zz_229;
+  wire       [13:0]   _zz_230;
+  wire       [31:0]   _zz_231;
+  wire       [31:0]   _zz_232;
+  wire       [31:0]   _zz_233;
+  wire                _zz_234;
+  wire       [0:0]    _zz_235;
+  wire       [7:0]    _zz_236;
+  wire       [31:0]   _zz_237;
+  wire       [31:0]   _zz_238;
+  wire       [31:0]   _zz_239;
+  wire                _zz_240;
   wire       [0:0]    _zz_241;
-  wire       [0:0]    _zz_242;
+  wire       [1:0]    _zz_242;
   wire                _zz_243;
   wire       [0:0]    _zz_244;
-  wire       [19:0]   _zz_245;
-  wire       [31:0]   _zz_246;
-  wire       [31:0]   _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
+  wire       [0:0]    _zz_245;
+  wire                _zz_246;
+  wire       [0:0]    _zz_247;
+  wire       [23:0]   _zz_248;
+  wire       [31:0]   _zz_249;
   wire                _zz_250;
-  wire       [2:0]    _zz_251;
-  wire       [2:0]    _zz_252;
-  wire                _zz_253;
+  wire                _zz_251;
+  wire       [0:0]    _zz_252;
+  wire       [0:0]    _zz_253;
   wire       [0:0]    _zz_254;
-  wire       [16:0]   _zz_255;
-  wire       [31:0]   _zz_256;
-  wire       [31:0]   _zz_257;
-  wire                _zz_258;
-  wire                _zz_259;
-  wire                _zz_260;
-  wire       [0:0]    _zz_261;
-  wire       [0:0]    _zz_262;
+  wire       [0:0]    _zz_255;
+  wire                _zz_256;
+  wire       [0:0]    _zz_257;
+  wire       [19:0]   _zz_258;
+  wire       [31:0]   _zz_259;
+  wire       [31:0]   _zz_260;
+  wire                _zz_261;
+  wire                _zz_262;
   wire                _zz_263;
-  wire       [0:0]    _zz_264;
-  wire       [0:0]    _zz_265;
+  wire       [2:0]    _zz_264;
+  wire       [2:0]    _zz_265;
   wire                _zz_266;
   wire       [0:0]    _zz_267;
-  wire       [13:0]   _zz_268;
+  wire       [16:0]   _zz_268;
   wire       [31:0]   _zz_269;
   wire       [31:0]   _zz_270;
   wire                _zz_271;
   wire                _zz_272;
-  wire       [0:0]    _zz_273;
+  wire                _zz_273;
   wire       [0:0]    _zz_274;
   wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire                _zz_277;
+  wire                _zz_276;
+  wire       [0:0]    _zz_277;
   wire       [0:0]    _zz_278;
-  wire       [10:0]   _zz_279;
-  wire       [31:0]   _zz_280;
-  wire       [31:0]   _zz_281;
-  wire                _zz_282;
-  wire                _zz_283;
+  wire                _zz_279;
+  wire       [0:0]    _zz_280;
+  wire       [13:0]   _zz_281;
+  wire       [31:0]   _zz_282;
+  wire       [31:0]   _zz_283;
   wire                _zz_284;
-  wire       [0:0]    _zz_285;
+  wire                _zz_285;
   wire       [0:0]    _zz_286;
-  wire                _zz_287;
+  wire       [0:0]    _zz_287;
   wire       [0:0]    _zz_288;
-  wire       [7:0]    _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [3:0]    _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [0:0]    _zz_293;
-  wire       [1:0]    _zz_294;
-  wire       [1:0]    _zz_295;
+  wire       [0:0]    _zz_289;
+  wire                _zz_290;
+  wire       [0:0]    _zz_291;
+  wire       [10:0]   _zz_292;
+  wire       [31:0]   _zz_293;
+  wire       [31:0]   _zz_294;
+  wire                _zz_295;
   wire                _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [3:0]    _zz_298;
-  wire       [31:0]   _zz_299;
-  wire       [31:0]   _zz_300;
-  wire       [31:0]   _zz_301;
-  wire       [0:0]    _zz_302;
-  wire       [0:0]    _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire                _zz_307;
-  wire       [0:0]    _zz_308;
+  wire                _zz_297;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire                _zz_300;
+  wire       [0:0]    _zz_301;
+  wire       [7:0]    _zz_302;
+  wire       [31:0]   _zz_303;
+  wire       [0:0]    _zz_304;
+  wire       [0:0]    _zz_305;
+  wire       [0:0]    _zz_306;
+  wire       [4:0]    _zz_307;
+  wire       [1:0]    _zz_308;
   wire       [1:0]    _zz_309;
   wire                _zz_310;
-  wire       [2:0]    _zz_311;
-  wire       [2:0]    _zz_312;
-  wire                _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [0:0]    _zz_315;
+  wire       [0:0]    _zz_311;
+  wire       [4:0]    _zz_312;
+  wire       [31:0]   _zz_313;
+  wire       [31:0]   _zz_314;
+  wire       [31:0]   _zz_315;
   wire       [31:0]   _zz_316;
-  wire       [31:0]   _zz_317;
-  wire       [31:0]   _zz_318;
-  wire       [31:0]   _zz_319;
+  wire                _zz_317;
+  wire       [0:0]    _zz_318;
+  wire       [1:0]    _zz_319;
   wire       [31:0]   _zz_320;
   wire       [31:0]   _zz_321;
-  wire       [31:0]   _zz_322;
-  wire                _zz_323;
-  wire       [31:0]   _zz_324;
-  wire                _zz_325;
+  wire                _zz_322;
+  wire       [0:0]    _zz_323;
+  wire       [2:0]    _zz_324;
+  wire       [0:0]    _zz_325;
   wire       [0:0]    _zz_326;
-  wire       [0:0]    _zz_327;
+  wire                _zz_327;
   wire       [0:0]    _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [1:0]    _zz_330;
-  wire       [1:0]    _zz_331;
-  wire       [0:0]    _zz_332;
-  wire       [0:0]    _zz_333;
-  wire       [31:0]   _zz_334;
+  wire       [1:0]    _zz_329;
+  wire       [31:0]   _zz_330;
+  wire       [31:0]   _zz_331;
+  wire       [31:0]   _zz_332;
+  wire                _zz_333;
+  wire                _zz_334;
   wire       [31:0]   _zz_335;
   wire       [31:0]   _zz_336;
   wire       [31:0]   _zz_337;
-  wire       [31:0]   _zz_338;
-  wire       [31:0]   _zz_339;
+  wire                _zz_338;
+  wire       [0:0]    _zz_339;
+  wire       [0:0]    _zz_340;
+  wire       [31:0]   _zz_341;
+  wire       [31:0]   _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [1:0]    _zz_344;
+  wire       [1:0]    _zz_345;
+  wire       [1:0]    _zz_346;
+  wire                _zz_347;
+  wire                _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [31:0]   _zz_351;
+  wire       [31:0]   _zz_352;
+  wire       [31:0]   _zz_353;
+  wire       [31:0]   _zz_354;
+  wire       [31:0]   _zz_355;
+  wire                _zz_356;
+  wire                _zz_357;
+  wire                _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [0:0]    _zz_360;
+  wire                _zz_361;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
-  wire       [31:0]   decode_SRC2;
-  wire       [31:0]   decode_SRC1;
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
   wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_4;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_7;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
   wire                decode_SRC_LESS_UNSIGNED;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
   wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       [31:0]   writeBack_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire                execute_IS_RS1_SIGNED;
-  wire                execute_IS_RS2_SIGNED;
   wire                execute_IS_MUL;
+  wire                execute_IS_RS2_SIGNED;
+  reg        [31:0]   _zz_26;
+  wire                memory_IS_MUL;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
+  wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_16;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                execute_BRANCH_DO;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       [31:0]   memory_BRANCH_CALC;
+  wire                memory_BRANCH_DO;
+  wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
+  wire                execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                memory_REGFILE_WRITE_VALID;
+  wire       [31:0]   memory_INSTRUCTION;
+  wire                memory_BYPASSABLE_MEMORY_STAGE;
+  wire                writeBack_REGFILE_WRITE_VALID;
+  reg        [31:0]   _zz_31;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_32;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_19;
-  wire       [31:0]   _zz_20;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
-  wire       [31:0]   _zz_22;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       [31:0]   _zz_33;
+  wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_35;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_36;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_25;
-  wire       [31:0]   _zz_26;
-  wire                _zz_27;
-  reg                 _zz_28;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_37;
+  wire       [31:0]   _zz_38;
+  wire                _zz_39;
+  reg                 _zz_40;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_32;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_33;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_34;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_35;
-  reg        [31:0]   _zz_36;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       [31:0]   execute_MEMORY_READ_DATA;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_41;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_47;
+  wire                writeBack_MEMORY_STORE;
+  reg        [31:0]   _zz_48;
+  wire                writeBack_MEMORY_ENABLE;
+  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   writeBack_MEMORY_READ_DATA;
+  wire                memory_MMU_FAULT;
+  wire       [31:0]   memory_MMU_RSP2_physicalAddress;
+  wire                memory_MMU_RSP2_isIoAccess;
+  wire                memory_MMU_RSP2_isPaging;
+  wire                memory_MMU_RSP2_allowRead;
+  wire                memory_MMU_RSP2_allowWrite;
+  wire                memory_MMU_RSP2_allowExecute;
+  wire                memory_MMU_RSP2_exception;
+  wire                memory_MMU_RSP2_refilling;
+  wire                memory_MMU_RSP2_bypassTranslation;
+  wire       [31:0]   memory_PC;
+  wire       [31:0]   memory_REGFILE_WRITE_DATA;
+  wire                memory_MEMORY_STORE;
+  wire                memory_MEMORY_ENABLE;
   wire                execute_MMU_FAULT;
   wire       [31:0]   execute_MMU_RSP2_physicalAddress;
   wire                execute_MMU_RSP2_isIoAccess;
@@ -408,6 +468,7 @@ module VexRiscv (
   wire                execute_MMU_RSP2_bypassTranslation;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
+  wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
@@ -416,9 +477,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
+  reg        [31:0]   _zz_49;
   wire       [31:0]   decode_PC;
-  wire       [31:0]   execute_PC;
-  wire       [31:0]   execute_INSTRUCTION;
+  wire       [31:0]   writeBack_PC;
+  wire       [31:0]   writeBack_INSTRUCTION;
   reg                 decode_arbitration_haltItself;
   reg                 decode_arbitration_haltByOther;
   reg                 decode_arbitration_removeIt;
@@ -433,7 +495,7 @@ module VexRiscv (
   reg                 execute_arbitration_haltItself;
   wire                execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
-  reg                 execute_arbitration_flushIt;
+  wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
   reg                 execute_arbitration_isValid;
   wire                execute_arbitration_isStuck;
@@ -441,6 +503,28 @@ module VexRiscv (
   wire                execute_arbitration_isFlushed;
   wire                execute_arbitration_isMoving;
   wire                execute_arbitration_isFiring;
+  reg                 memory_arbitration_haltItself;
+  wire                memory_arbitration_haltByOther;
+  reg                 memory_arbitration_removeIt;
+  reg                 memory_arbitration_flushIt;
+  reg                 memory_arbitration_flushNext;
+  reg                 memory_arbitration_isValid;
+  wire                memory_arbitration_isStuck;
+  wire                memory_arbitration_isStuckByOthers;
+  wire                memory_arbitration_isFlushed;
+  wire                memory_arbitration_isMoving;
+  wire                memory_arbitration_isFiring;
+  wire                writeBack_arbitration_haltItself;
+  wire                writeBack_arbitration_haltByOther;
+  reg                 writeBack_arbitration_removeIt;
+  wire                writeBack_arbitration_flushIt;
+  reg                 writeBack_arbitration_flushNext;
+  reg                 writeBack_arbitration_isValid;
+  wire                writeBack_arbitration_isStuck;
+  wire                writeBack_arbitration_isStuckByOthers;
+  wire                writeBack_arbitration_isFlushed;
+  wire                writeBack_arbitration_isMoving;
+  wire                writeBack_arbitration_isFiring;
   wire       [31:0]   lastStageInstruction /* verilator public */ ;
   wire       [31:0]   lastStagePc /* verilator public */ ;
   wire                lastStageIsValid /* verilator public */ ;
@@ -449,6 +533,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_pcValids_0;
   wire                IBusCachedPlugin_pcValids_1;
+  wire                IBusCachedPlugin_pcValids_2;
+  wire                IBusCachedPlugin_pcValids_3;
   wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
   wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
   wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
@@ -495,6 +581,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_jumpInterface_payload;
   wire                CsrPlugin_exceptionPendings_0;
   wire                CsrPlugin_exceptionPendings_1;
+  wire                CsrPlugin_exceptionPendings_2;
+  wire                CsrPlugin_exceptionPendings_3;
   wire                externalInterrupt;
   wire                contextSwitching;
   reg        [1:0]    CsrPlugin_privilege;
@@ -507,10 +595,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_37;
-  wire       [2:0]    _zz_38;
-  wire                _zz_39;
-  wire                _zz_40;
+  wire       [2:0]    _zz_50;
+  wire       [2:0]    _zz_51;
+  wire                _zz_52;
+  wire                _zz_53;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -547,16 +635,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_41;
-  wire                _zz_42;
-  wire                _zz_43;
+  wire                _zz_54;
+  wire                _zz_55;
+  wire                _zz_56;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_44;
-  wire                _zz_45;
-  reg                 _zz_46;
-  wire                _zz_47;
-  reg                 _zz_48;
-  reg        [31:0]   _zz_49;
+  wire                _zz_57;
+  wire                _zz_58;
+  reg                 _zz_59;
+  wire                _zz_60;
+  reg                 _zz_61;
+  reg        [31:0]   _zz_62;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -567,6 +655,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -574,7 +664,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_50;
+  wire       [31:0]   _zz_63;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -591,32 +681,31 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  reg                 _zz_51;
-  reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_52;
-  reg        [3:0]    _zz_53;
-  wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  reg        [31:0]   execute_DBusSimplePlugin_rspShifted;
-  wire                _zz_54;
-  reg        [31:0]   _zz_55;
-  wire                _zz_56;
-  reg        [31:0]   _zz_57;
-  reg        [31:0]   execute_DBusSimplePlugin_rspFormated;
-  wire       [29:0]   _zz_58;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
-  wire                _zz_63;
   wire                _zz_64;
-  wire                _zz_65;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_66;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_67;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_68;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_69;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_70;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_71;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_72;
+  reg                 execute_DBusSimplePlugin_skipCmd;
+  reg        [31:0]   _zz_65;
+  reg        [3:0]    _zz_66;
+  wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
+  wire                _zz_67;
+  reg        [31:0]   _zz_68;
+  wire                _zz_69;
+  reg        [31:0]   _zz_70;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
+  wire       [29:0]   _zz_71;
+  wire                _zz_72;
+  wire                _zz_73;
+  wire                _zz_74;
+  wire                _zz_75;
+  wire                _zz_76;
+  wire                _zz_77;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_78;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_79;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_80;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_81;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_82;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_83;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_84;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -624,41 +713,40 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_73;
+  reg                 _zz_85;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_74;
-  reg        [31:0]   _zz_75;
-  wire                _zz_76;
-  reg        [19:0]   _zz_77;
-  wire                _zz_78;
-  reg        [19:0]   _zz_79;
-  reg        [31:0]   _zz_80;
+  reg        [31:0]   _zz_86;
+  reg        [31:0]   _zz_87;
+  wire                _zz_88;
+  reg        [19:0]   _zz_89;
+  wire                _zz_90;
+  reg        [19:0]   _zz_91;
+  reg        [31:0]   _zz_92;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
   wire                execute_LightShifterPlugin_isShift;
   reg        [4:0]    execute_LightShifterPlugin_amplitudeReg;
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
-  reg        [31:0]   execute_LightShifterPlugin_shiftReg;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_81;
-  reg                 _zz_82;
-  reg                 _zz_83;
-  reg                 _zz_84;
-  reg        [4:0]    _zz_85;
+  reg        [31:0]   _zz_93;
+  reg                 _zz_94;
+  reg                 _zz_95;
+  reg                 _zz_96;
+  reg        [4:0]    _zz_97;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_86;
-  reg                 _zz_87;
-  reg                 _zz_88;
+  wire       [2:0]    _zz_98;
+  reg                 _zz_99;
+  reg                 _zz_100;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_89;
-  reg        [10:0]   _zz_90;
-  wire                _zz_91;
-  reg        [19:0]   _zz_92;
-  wire                _zz_93;
-  reg        [18:0]   _zz_94;
-  reg        [31:0]   _zz_95;
+  wire                _zz_101;
+  reg        [10:0]   _zz_102;
+  wire                _zz_103;
+  reg        [19:0]   _zz_104;
+  wire                _zz_105;
+  reg        [18:0]   _zz_106;
+  reg        [31:0]   _zz_107;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -680,25 +768,29 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_96;
-  wire                _zz_97;
-  wire                _zz_98;
+  wire                _zz_108;
+  wire                _zz_109;
+  wire                _zz_110;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_99;
-  wire                _zz_100;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_1;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
@@ -719,29 +811,46 @@ module VexRiscv (
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
   reg        [31:0]   execute_CsrPlugin_writeData;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
-  reg        [32:0]   execute_MulDivIterativePlugin_rs1;
-  reg        [31:0]   execute_MulDivIterativePlugin_rs2;
-  reg        [64:0]   execute_MulDivIterativePlugin_accumulator;
-  reg                 execute_MulDivIterativePlugin_frontendOk;
-  reg                 execute_MulDivIterativePlugin_mul_counter_willIncrement;
-  reg                 execute_MulDivIterativePlugin_mul_counter_willClear;
-  reg        [5:0]    execute_MulDivIterativePlugin_mul_counter_valueNext;
-  reg        [5:0]    execute_MulDivIterativePlugin_mul_counter_value;
-  wire                execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
-  wire                execute_MulDivIterativePlugin_mul_counter_willOverflow;
-  wire                _zz_101;
-  wire                _zz_102;
-  reg        [32:0]   _zz_103;
+  reg        [32:0]   memory_MulDivIterativePlugin_rs1;
+  reg        [31:0]   memory_MulDivIterativePlugin_rs2;
+  reg        [64:0]   memory_MulDivIterativePlugin_accumulator;
+  wire                memory_MulDivIterativePlugin_frontendOk;
+  reg                 memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  reg                 memory_MulDivIterativePlugin_mul_counter_willClear;
+  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_valueNext;
+  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
+  wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
+  wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
+  wire                _zz_111;
+  wire                _zz_112;
+  reg        [32:0]   _zz_113;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_104;
-  wire       [31:0]   _zz_105;
+  reg        [31:0]   _zz_114;
+  wire       [31:0]   _zz_115;
   reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_STORE;
+  reg                 execute_to_memory_MEMORY_STORE;
+  reg                 memory_to_writeBack_MEMORY_STORE;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
@@ -749,16 +858,34 @@ module VexRiscv (
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
   reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
   reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_SRC1;
-  reg        [31:0]   decode_to_execute_SRC2;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_MMU_FAULT;
+  reg        [31:0]   execute_to_memory_MMU_RSP2_physicalAddress;
+  reg                 execute_to_memory_MMU_RSP2_isIoAccess;
+  reg                 execute_to_memory_MMU_RSP2_isPaging;
+  reg                 execute_to_memory_MMU_RSP2_allowRead;
+  reg                 execute_to_memory_MMU_RSP2_allowWrite;
+  reg                 execute_to_memory_MMU_RSP2_allowExecute;
+  reg                 execute_to_memory_MMU_RSP2_exception;
+  reg                 execute_to_memory_MMU_RSP2_refilling;
+  reg                 execute_to_memory_MMU_RSP2_bypassTranslation;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -770,18 +897,18 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_2944;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_106;
-  reg        [31:0]   _zz_107;
-  reg        [31:0]   _zz_108;
-  reg        [31:0]   _zz_109;
-  reg        [31:0]   _zz_110;
-  reg        [31:0]   _zz_111;
-  reg        [31:0]   _zz_112;
-  reg        [31:0]   _zz_113;
-  reg        [31:0]   _zz_114;
-  reg        [31:0]   _zz_115;
-  reg        [2:0]    _zz_116;
-  reg                 _zz_117;
+  reg        [31:0]   _zz_116;
+  reg        [31:0]   _zz_117;
+  reg        [31:0]   _zz_118;
+  reg        [31:0]   _zz_119;
+  reg        [31:0]   _zz_120;
+  reg        [31:0]   _zz_121;
+  reg        [31:0]   _zz_122;
+  reg        [31:0]   _zz_123;
+  reg        [31:0]   _zz_124;
+  reg        [31:0]   _zz_125;
+  reg        [2:0]    _zz_126;
+  reg                 _zz_127;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -795,300 +922,332 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_118;
+  reg        [3:0]    _zz_128;
   `ifndef SYNTHESIS
-  reg [39:0] decode_ENV_CTRL_string;
   reg [39:0] _zz_1_string;
   reg [39:0] _zz_2_string;
   reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
+  reg [39:0] decode_ENV_CTRL_string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_4_string;
-  reg [31:0] _zz_5_string;
-  reg [31:0] _zz_6_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [31:0] _zz_10_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_7_string;
-  reg [71:0] _zz_8_string;
-  reg [71:0] _zz_9_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_10_string;
-  reg [39:0] _zz_11_string;
-  reg [39:0] _zz_12_string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_13_string;
-  reg [63:0] _zz_14_string;
-  reg [63:0] _zz_15_string;
-  reg [39:0] execute_ENV_CTRL_string;
+  reg [39:0] _zz_14_string;
+  reg [39:0] _zz_15_string;
   reg [39:0] _zz_16_string;
-  reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_17_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_18_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_17_string;
+  reg [63:0] _zz_18_string;
+  reg [63:0] _zz_19_string;
   reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_20_string;
   reg [23:0] _zz_21_string;
+  reg [23:0] _zz_22_string;
   reg [95:0] decode_SRC1_CTRL_string;
   reg [95:0] _zz_23_string;
-  reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_24_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_25_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [39:0] memory_ENV_CTRL_string;
+  reg [39:0] _zz_27_string;
+  reg [39:0] execute_ENV_CTRL_string;
+  reg [39:0] _zz_28_string;
+  reg [39:0] writeBack_ENV_CTRL_string;
   reg [39:0] _zz_29_string;
+  reg [31:0] execute_BRANCH_CTRL_string;
   reg [31:0] _zz_30_string;
-  reg [71:0] _zz_31_string;
-  reg [39:0] _zz_32_string;
-  reg [63:0] _zz_33_string;
+  reg [71:0] execute_SHIFT_CTRL_string;
+  reg [71:0] _zz_32_string;
+  reg [23:0] execute_SRC2_CTRL_string;
   reg [23:0] _zz_34_string;
+  reg [95:0] execute_SRC1_CTRL_string;
   reg [95:0] _zz_35_string;
-  reg [95:0] _zz_66_string;
-  reg [23:0] _zz_67_string;
-  reg [63:0] _zz_68_string;
-  reg [39:0] _zz_69_string;
-  reg [71:0] _zz_70_string;
-  reg [31:0] _zz_71_string;
-  reg [39:0] _zz_72_string;
+  reg [63:0] execute_ALU_CTRL_string;
+  reg [63:0] _zz_36_string;
+  reg [39:0] execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_37_string;
+  reg [39:0] _zz_41_string;
+  reg [31:0] _zz_42_string;
+  reg [71:0] _zz_43_string;
+  reg [39:0] _zz_44_string;
+  reg [63:0] _zz_45_string;
+  reg [23:0] _zz_46_string;
+  reg [95:0] _zz_47_string;
+  reg [95:0] _zz_78_string;
+  reg [23:0] _zz_79_string;
+  reg [63:0] _zz_80_string;
+  reg [39:0] _zz_81_string;
+  reg [71:0] _zz_82_string;
+  reg [31:0] _zz_83_string;
+  reg [39:0] _zz_84_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
+  reg [39:0] execute_to_memory_ENV_CTRL_string;
+  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_131 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_132 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_133 = (execute_arbitration_isValid && execute_IS_MUL);
-  assign _zz_134 = ((_zz_124 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_135 = ((_zz_124 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_136 = (execute_MulDivIterativePlugin_frontendOk && (! execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_137 = ({CsrPlugin_selfException_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_138 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_139 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_140 = execute_INSTRUCTION[29 : 28];
-  assign _zz_141 = (! ((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (1'b0 || (! execute_arbitration_isStuckByOthers))));
-  assign _zz_142 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_143 = (1'b1 || (! 1'b1));
-  assign _zz_144 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_145 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_146 = (iBus_cmd_valid || (_zz_116 != 3'b000));
-  assign _zz_147 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_148 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_149 = ((_zz_96 && 1'b1) && (! 1'b0));
-  assign _zz_150 = ((_zz_97 && 1'b1) && (! 1'b0));
-  assign _zz_151 = ((_zz_98 && 1'b1) && (! 1'b0));
-  assign _zz_152 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_153 = execute_INSTRUCTION[13 : 12];
-  assign _zz_154 = execute_INSTRUCTION[13];
-  assign _zz_155 = _zz_58[29 : 29];
-  assign _zz_156 = _zz_58[28 : 28];
-  assign _zz_157 = _zz_58[27 : 27];
-  assign _zz_158 = _zz_58[24 : 24];
-  assign _zz_159 = _zz_58[15 : 15];
-  assign _zz_160 = _zz_58[11 : 11];
-  assign _zz_161 = _zz_58[12 : 12];
-  assign _zz_162 = _zz_58[5 : 5];
-  assign _zz_163 = _zz_58[3 : 3];
-  assign _zz_164 = _zz_58[18 : 18];
-  assign _zz_165 = _zz_58[8 : 8];
-  assign _zz_166 = _zz_58[4 : 4];
-  assign _zz_167 = _zz_58[0 : 0];
-  assign _zz_168 = (_zz_37 - 3'b001);
-  assign _zz_169 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_170 = {29'd0, _zz_169};
-  assign _zz_171 = execute_SRC_LESS;
-  assign _zz_172 = 3'b100;
-  assign _zz_173 = decode_INSTRUCTION[19 : 15];
-  assign _zz_174 = decode_INSTRUCTION[31 : 20];
-  assign _zz_175 = {decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]};
-  assign _zz_176 = ($signed(_zz_177) + $signed(_zz_180));
-  assign _zz_177 = ($signed(_zz_178) + $signed(_zz_179));
-  assign _zz_178 = execute_SRC1;
-  assign _zz_179 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_180 = (execute_SRC_USE_SUB_LESS ? _zz_181 : _zz_182);
-  assign _zz_181 = 32'h00000001;
-  assign _zz_182 = 32'h0;
-  assign _zz_183 = (_zz_184 >>> 1);
-  assign _zz_184 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_185 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_186 = execute_INSTRUCTION[31 : 20];
-  assign _zz_187 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_188 = (_zz_99 & (~ _zz_189));
-  assign _zz_189 = (_zz_99 - 2'b01);
-  assign _zz_190 = execute_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_191 = {5'd0, _zz_190};
-  assign _zz_192 = (_zz_194 + _zz_196);
-  assign _zz_193 = (execute_MulDivIterativePlugin_rs2[0] ? execute_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_194 = {{1{_zz_193[32]}}, _zz_193};
-  assign _zz_195 = _zz_197;
-  assign _zz_196 = {{1{_zz_195[32]}}, _zz_195};
-  assign _zz_197 = (execute_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_198 = _zz_102;
-  assign _zz_199 = {32'd0, _zz_198};
-  assign _zz_200 = _zz_101;
-  assign _zz_201 = {31'd0, _zz_200};
-  assign _zz_202 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_203 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_204 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_205 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_206 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_207 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_208 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_209 = 1'b1;
-  assign _zz_210 = 1'b1;
-  assign _zz_211 = {_zz_40,_zz_39};
-  assign _zz_212 = 32'h0000107f;
-  assign _zz_213 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_214 = 32'h00002073;
-  assign _zz_215 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_216 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_217 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_218) == 32'h00000003),{(_zz_219 == _zz_220),{_zz_221,{_zz_222,_zz_223}}}}}};
-  assign _zz_218 = 32'h0000505f;
-  assign _zz_219 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_220 = 32'h00000063;
-  assign _zz_221 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_222 = ((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033);
-  assign _zz_223 = {((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_224) == 32'h00001013),{(_zz_225 == _zz_226),{_zz_227,{_zz_228,_zz_229}}}}}};
-  assign _zz_224 = 32'hfc00705f;
-  assign _zz_225 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_226 = 32'h00005033;
-  assign _zz_227 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_228 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_229 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_230 = ((decode_INSTRUCTION & 32'h02000074) == 32'h02000030);
-  assign _zz_231 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
-  assign _zz_232 = 1'b0;
-  assign _zz_233 = (((decode_INSTRUCTION & _zz_236) == 32'h10000050) != 1'b0);
-  assign _zz_234 = ({_zz_237,_zz_238} != 2'b00);
-  assign _zz_235 = {({_zz_239,_zz_240} != 2'b00),{(_zz_241 != _zz_242),{_zz_243,{_zz_244,_zz_245}}}};
-  assign _zz_236 = 32'h10403050;
-  assign _zz_237 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_238 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_239 = _zz_63;
-  assign _zz_240 = ((decode_INSTRUCTION & _zz_246) == 32'h00000004);
-  assign _zz_241 = ((decode_INSTRUCTION & _zz_247) == 32'h00000040);
-  assign _zz_242 = 1'b0;
-  assign _zz_243 = ({_zz_248,_zz_249} != 2'b00);
-  assign _zz_244 = (_zz_250 != 1'b0);
-  assign _zz_245 = {(_zz_251 != _zz_252),{_zz_253,{_zz_254,_zz_255}}};
-  assign _zz_246 = 32'h0000001c;
-  assign _zz_247 = 32'h00000058;
-  assign _zz_248 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_249 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz_250 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
-  assign _zz_251 = {(_zz_256 == _zz_257),{_zz_258,_zz_259}};
-  assign _zz_252 = 3'b000;
-  assign _zz_253 = ({_zz_260,{_zz_261,_zz_262}} != 3'b000);
-  assign _zz_254 = (_zz_263 != 1'b0);
-  assign _zz_255 = {(_zz_264 != _zz_265),{_zz_266,{_zz_267,_zz_268}}};
-  assign _zz_256 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_257 = 32'h40001010;
-  assign _zz_258 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz_259 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz_260 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_261 = ((decode_INSTRUCTION & _zz_269) == 32'h00001010);
-  assign _zz_262 = ((decode_INSTRUCTION & _zz_270) == 32'h00001010);
-  assign _zz_263 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_264 = _zz_64;
-  assign _zz_265 = 1'b0;
-  assign _zz_266 = ({_zz_271,_zz_272} != 2'b00);
-  assign _zz_267 = ({_zz_273,_zz_274} != 2'b00);
-  assign _zz_268 = {(_zz_275 != _zz_276),{_zz_277,{_zz_278,_zz_279}}};
-  assign _zz_269 = 32'h00003034;
-  assign _zz_270 = 32'h02003054;
-  assign _zz_271 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_272 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_273 = ((decode_INSTRUCTION & _zz_280) == 32'h00006000);
-  assign _zz_274 = ((decode_INSTRUCTION & _zz_281) == 32'h00004000);
-  assign _zz_275 = _zz_60;
-  assign _zz_276 = 1'b0;
-  assign _zz_277 = ({_zz_282,_zz_283} != 2'b00);
-  assign _zz_278 = (_zz_284 != 1'b0);
-  assign _zz_279 = {(_zz_285 != _zz_286),{_zz_287,{_zz_288,_zz_289}}};
-  assign _zz_280 = 32'h00006004;
-  assign _zz_281 = 32'h00005004;
-  assign _zz_282 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_283 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_284 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_285 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz_286 = 1'b0;
-  assign _zz_287 = (_zz_62 != 1'b0);
-  assign _zz_288 = ({_zz_63,{_zz_290,_zz_291}} != 6'h0);
-  assign _zz_289 = {({_zz_292,_zz_293} != 2'b00),{(_zz_294 != _zz_295),{_zz_296,{_zz_297,_zz_298}}}};
-  assign _zz_290 = ((decode_INSTRUCTION & _zz_299) == 32'h00001010);
-  assign _zz_291 = {(_zz_300 == _zz_301),{_zz_62,{_zz_302,_zz_303}}};
-  assign _zz_292 = _zz_61;
-  assign _zz_293 = ((decode_INSTRUCTION & _zz_304) == 32'h00000020);
-  assign _zz_294 = {_zz_61,(_zz_305 == _zz_306)};
-  assign _zz_295 = 2'b00;
-  assign _zz_296 = ({_zz_307,{_zz_308,_zz_309}} != 4'b0000);
-  assign _zz_297 = (_zz_310 != 1'b0);
-  assign _zz_298 = {(_zz_311 != _zz_312),{_zz_313,{_zz_314,_zz_315}}};
-  assign _zz_299 = 32'h00001010;
-  assign _zz_300 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_301 = 32'h00002010;
-  assign _zz_302 = (_zz_316 == _zz_317);
-  assign _zz_303 = (_zz_318 == _zz_319);
-  assign _zz_304 = 32'h00000070;
-  assign _zz_305 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_306 = 32'h0;
-  assign _zz_307 = ((decode_INSTRUCTION & _zz_320) == 32'h0);
-  assign _zz_308 = (_zz_321 == _zz_322);
-  assign _zz_309 = {_zz_60,_zz_323};
-  assign _zz_310 = ((decode_INSTRUCTION & _zz_324) == 32'h0);
-  assign _zz_311 = {_zz_325,{_zz_326,_zz_327}};
-  assign _zz_312 = 3'b000;
-  assign _zz_313 = ({_zz_328,_zz_329} != 2'b00);
-  assign _zz_314 = (_zz_330 != _zz_331);
-  assign _zz_315 = (_zz_332 != _zz_333);
-  assign _zz_316 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_317 = 32'h00000004;
-  assign _zz_318 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_319 = 32'h0;
-  assign _zz_320 = 32'h00000044;
-  assign _zz_321 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_322 = 32'h0;
-  assign _zz_323 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_324 = 32'h00000058;
-  assign _zz_325 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_326 = ((decode_INSTRUCTION & _zz_334) == 32'h00002010);
-  assign _zz_327 = ((decode_INSTRUCTION & _zz_335) == 32'h40000030);
-  assign _zz_328 = ((decode_INSTRUCTION & _zz_336) == 32'h00000004);
-  assign _zz_329 = _zz_59;
-  assign _zz_330 = {(_zz_337 == _zz_338),_zz_59};
-  assign _zz_331 = 2'b00;
-  assign _zz_332 = ((decode_INSTRUCTION & _zz_339) == 32'h00001008);
-  assign _zz_333 = 1'b0;
-  assign _zz_334 = 32'h00002014;
-  assign _zz_335 = 32'h40004034;
-  assign _zz_336 = 32'h00000014;
-  assign _zz_337 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_338 = 32'h00000004;
-  assign _zz_339 = 32'h00001048;
+  assign _zz_141 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign _zz_142 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_143 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_144 = ((_zz_134 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_145 = ((_zz_134 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_146 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign _zz_147 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_148 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_149 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_150 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign _zz_151 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_152 = (1'b1 || (! 1'b1));
+  assign _zz_153 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_154 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_155 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_156 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_157 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_158 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_159 = (iBus_cmd_valid || (_zz_126 != 3'b000));
+  assign _zz_160 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_161 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_162 = ((_zz_108 && 1'b1) && (! 1'b0));
+  assign _zz_163 = ((_zz_109 && 1'b1) && (! 1'b0));
+  assign _zz_164 = ((_zz_110 && 1'b1) && (! 1'b0));
+  assign _zz_165 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_166 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_167 = execute_INSTRUCTION[13];
+  assign _zz_168 = _zz_71[29 : 29];
+  assign _zz_169 = _zz_71[28 : 28];
+  assign _zz_170 = _zz_71[27 : 27];
+  assign _zz_171 = _zz_71[24 : 24];
+  assign _zz_172 = _zz_71[15 : 15];
+  assign _zz_173 = _zz_71[11 : 11];
+  assign _zz_174 = _zz_71[10 : 10];
+  assign _zz_175 = _zz_71[9 : 9];
+  assign _zz_176 = _zz_71[12 : 12];
+  assign _zz_177 = _zz_71[5 : 5];
+  assign _zz_178 = _zz_71[3 : 3];
+  assign _zz_179 = _zz_71[18 : 18];
+  assign _zz_180 = _zz_71[8 : 8];
+  assign _zz_181 = _zz_71[4 : 4];
+  assign _zz_182 = _zz_71[0 : 0];
+  assign _zz_183 = (_zz_50 - 3'b001);
+  assign _zz_184 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_185 = {29'd0, _zz_184};
+  assign _zz_186 = execute_SRC_LESS;
+  assign _zz_187 = 3'b100;
+  assign _zz_188 = execute_INSTRUCTION[19 : 15];
+  assign _zz_189 = execute_INSTRUCTION[31 : 20];
+  assign _zz_190 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_191 = ($signed(_zz_192) + $signed(_zz_195));
+  assign _zz_192 = ($signed(_zz_193) + $signed(_zz_194));
+  assign _zz_193 = execute_SRC1;
+  assign _zz_194 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_195 = (execute_SRC_USE_SUB_LESS ? _zz_196 : _zz_197);
+  assign _zz_196 = 32'h00000001;
+  assign _zz_197 = 32'h0;
+  assign _zz_198 = (_zz_199 >>> 1);
+  assign _zz_199 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_200 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_201 = execute_INSTRUCTION[31 : 20];
+  assign _zz_202 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_203 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_204 = {5'd0, _zz_203};
+  assign _zz_205 = (_zz_207 + _zz_209);
+  assign _zz_206 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_207 = {{1{_zz_206[32]}}, _zz_206};
+  assign _zz_208 = _zz_210;
+  assign _zz_209 = {{1{_zz_208[32]}}, _zz_208};
+  assign _zz_210 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_211 = _zz_112;
+  assign _zz_212 = {32'd0, _zz_211};
+  assign _zz_213 = _zz_111;
+  assign _zz_214 = {31'd0, _zz_213};
+  assign _zz_215 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_216 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_217 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_218 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_219 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_220 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_221 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_222 = 1'b1;
+  assign _zz_223 = 1'b1;
+  assign _zz_224 = {_zz_53,_zz_52};
+  assign _zz_225 = 32'h0000107f;
+  assign _zz_226 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_227 = 32'h00002073;
+  assign _zz_228 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_229 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_230 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_231) == 32'h00000003),{(_zz_232 == _zz_233),{_zz_234,{_zz_235,_zz_236}}}}}};
+  assign _zz_231 = 32'h0000505f;
+  assign _zz_232 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_233 = 32'h00000063;
+  assign _zz_234 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_235 = ((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033);
+  assign _zz_236 = {((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_237) == 32'h00001013),{(_zz_238 == _zz_239),{_zz_240,{_zz_241,_zz_242}}}}}};
+  assign _zz_237 = 32'hfc00705f;
+  assign _zz_238 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_239 = 32'h00005033;
+  assign _zz_240 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_241 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_242 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_243 = ((decode_INSTRUCTION & 32'h02000074) == 32'h02000030);
+  assign _zz_244 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz_245 = 1'b0;
+  assign _zz_246 = (((decode_INSTRUCTION & _zz_249) == 32'h10000050) != 1'b0);
+  assign _zz_247 = ({_zz_250,_zz_251} != 2'b00);
+  assign _zz_248 = {({_zz_252,_zz_253} != 2'b00),{(_zz_254 != _zz_255),{_zz_256,{_zz_257,_zz_258}}}};
+  assign _zz_249 = 32'h10403050;
+  assign _zz_250 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_251 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_252 = _zz_75;
+  assign _zz_253 = ((decode_INSTRUCTION & _zz_259) == 32'h00000004);
+  assign _zz_254 = ((decode_INSTRUCTION & _zz_260) == 32'h00000040);
+  assign _zz_255 = 1'b0;
+  assign _zz_256 = ({_zz_261,_zz_262} != 2'b00);
+  assign _zz_257 = (_zz_263 != 1'b0);
+  assign _zz_258 = {(_zz_264 != _zz_265),{_zz_266,{_zz_267,_zz_268}}};
+  assign _zz_259 = 32'h0000001c;
+  assign _zz_260 = 32'h00000058;
+  assign _zz_261 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz_262 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
+  assign _zz_263 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
+  assign _zz_264 = {(_zz_269 == _zz_270),{_zz_271,_zz_272}};
+  assign _zz_265 = 3'b000;
+  assign _zz_266 = ({_zz_273,{_zz_274,_zz_275}} != 3'b000);
+  assign _zz_267 = (_zz_276 != 1'b0);
+  assign _zz_268 = {(_zz_277 != _zz_278),{_zz_279,{_zz_280,_zz_281}}};
+  assign _zz_269 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz_270 = 32'h40001010;
+  assign _zz_271 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz_272 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz_273 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_274 = ((decode_INSTRUCTION & _zz_282) == 32'h00001010);
+  assign _zz_275 = ((decode_INSTRUCTION & _zz_283) == 32'h00001010);
+  assign _zz_276 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz_277 = _zz_76;
+  assign _zz_278 = 1'b0;
+  assign _zz_279 = ({_zz_284,_zz_285} != 2'b00);
+  assign _zz_280 = ({_zz_286,_zz_287} != 2'b00);
+  assign _zz_281 = {(_zz_288 != _zz_289),{_zz_290,{_zz_291,_zz_292}}};
+  assign _zz_282 = 32'h00003034;
+  assign _zz_283 = 32'h02003054;
+  assign _zz_284 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_285 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz_286 = ((decode_INSTRUCTION & _zz_293) == 32'h00006000);
+  assign _zz_287 = ((decode_INSTRUCTION & _zz_294) == 32'h00004000);
+  assign _zz_288 = _zz_73;
+  assign _zz_289 = 1'b0;
+  assign _zz_290 = ({_zz_295,_zz_296} != 2'b00);
+  assign _zz_291 = (_zz_297 != 1'b0);
+  assign _zz_292 = {(_zz_298 != _zz_299),{_zz_300,{_zz_301,_zz_302}}};
+  assign _zz_293 = 32'h00006004;
+  assign _zz_294 = 32'h00005004;
+  assign _zz_295 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz_296 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_297 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz_298 = ((decode_INSTRUCTION & _zz_303) == 32'h00000010);
+  assign _zz_299 = 1'b0;
+  assign _zz_300 = ({_zz_74,{_zz_304,_zz_305}} != 3'b000);
+  assign _zz_301 = ({_zz_306,_zz_307} != 6'h0);
+  assign _zz_302 = {(_zz_308 != _zz_309),{_zz_310,{_zz_311,_zz_312}}};
+  assign _zz_303 = 32'h00000010;
+  assign _zz_304 = ((decode_INSTRUCTION & _zz_313) == 32'h00000010);
+  assign _zz_305 = ((decode_INSTRUCTION & _zz_314) == 32'h00000020);
+  assign _zz_306 = _zz_75;
+  assign _zz_307 = {(_zz_315 == _zz_316),{_zz_317,{_zz_318,_zz_319}}};
+  assign _zz_308 = {_zz_74,(_zz_320 == _zz_321)};
+  assign _zz_309 = 2'b00;
+  assign _zz_310 = ({_zz_74,_zz_322} != 2'b00);
+  assign _zz_311 = ({_zz_323,_zz_324} != 4'b0000);
+  assign _zz_312 = {(_zz_325 != _zz_326),{_zz_327,{_zz_328,_zz_329}}};
+  assign _zz_313 = 32'h00000030;
+  assign _zz_314 = 32'h02000060;
+  assign _zz_315 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_316 = 32'h00001010;
+  assign _zz_317 = ((decode_INSTRUCTION & _zz_330) == 32'h00002010);
+  assign _zz_318 = (_zz_331 == _zz_332);
+  assign _zz_319 = {_zz_333,_zz_334};
+  assign _zz_320 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_321 = 32'h00000020;
+  assign _zz_322 = ((decode_INSTRUCTION & _zz_335) == 32'h0);
+  assign _zz_323 = (_zz_336 == _zz_337);
+  assign _zz_324 = {_zz_338,{_zz_339,_zz_340}};
+  assign _zz_325 = (_zz_341 == _zz_342);
+  assign _zz_326 = 1'b0;
+  assign _zz_327 = ({_zz_343,_zz_344} != 3'b000);
+  assign _zz_328 = (_zz_345 != _zz_346);
+  assign _zz_329 = {_zz_347,_zz_348};
+  assign _zz_330 = 32'h00002010;
+  assign _zz_331 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_332 = 32'h00000010;
+  assign _zz_333 = ((decode_INSTRUCTION & _zz_349) == 32'h00000004);
+  assign _zz_334 = ((decode_INSTRUCTION & _zz_350) == 32'h0);
+  assign _zz_335 = 32'h00000020;
+  assign _zz_336 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_337 = 32'h0;
+  assign _zz_338 = ((decode_INSTRUCTION & _zz_351) == 32'h0);
+  assign _zz_339 = _zz_73;
+  assign _zz_340 = (_zz_352 == _zz_353);
+  assign _zz_341 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_342 = 32'h0;
+  assign _zz_343 = (_zz_354 == _zz_355);
+  assign _zz_344 = {_zz_356,_zz_357};
+  assign _zz_345 = {_zz_358,_zz_72};
+  assign _zz_346 = 2'b00;
+  assign _zz_347 = ({_zz_359,_zz_360} != 2'b00);
+  assign _zz_348 = (_zz_361 != 1'b0);
+  assign _zz_349 = 32'h0000000c;
+  assign _zz_350 = 32'h00000028;
+  assign _zz_351 = 32'h00000018;
+  assign _zz_352 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_353 = 32'h00001000;
+  assign _zz_354 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_355 = 32'h00000040;
+  assign _zz_356 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_357 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz_358 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_359 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_360 = _zz_72;
+  assign _zz_361 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
   always @ (posedge clk) begin
-    if(_zz_209) begin
-      _zz_128 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_222) begin
+      _zz_138 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_210) begin
-      _zz_129 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_223) begin
+      _zz_139 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_28) begin
+    if(_zz_40) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_119                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_120                                                     ), //i
+    .io_flush                                 (_zz_129                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_130                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_121                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_122                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_123                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_131                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_132                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_133                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1101,8 +1260,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_124                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_125                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_134                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_135                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1110,8 +1269,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_126                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_127                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_136                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_137                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1124,28 +1283,20 @@ module VexRiscv (
     .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_211)
+    case(_zz_224)
       2'b00 : begin
-        _zz_130 = DBusSimplePlugin_redoBranch_payload;
+        _zz_140 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_130 = CsrPlugin_jumpInterface_payload;
+        _zz_140 = DBusSimplePlugin_redoBranch_payload;
       end
       default : begin
-        _zz_130 = BranchPlugin_jumpInterface_payload;
+        _zz_140 = BranchPlugin_jumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
-  always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
-    endcase
-  end
   always @(*) begin
     case(_zz_1)
       `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
@@ -1171,6 +1322,46 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
       `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
@@ -1180,30 +1371,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_4_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_4_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_4_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_4_string = "JALR";
-      default : _zz_4_string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_5_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_5_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_5_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_5_string = "JALR";
-      default : _zz_5_string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_6_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_6_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_6_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_6_string = "JALR";
-      default : _zz_6_string = "????";
+    case(_zz_10)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
+      default : _zz_10_string = "????";
     endcase
   end
   always @(*) begin
@@ -1216,30 +1407,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_7_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_7_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_7_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_7_string = "SRA_1    ";
-      default : _zz_7_string = "?????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_8_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_8_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_8_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_8_string = "SRA_1    ";
-      default : _zz_8_string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_9_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_9_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_9_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_9_string = "SRA_1    ";
-      default : _zz_9_string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1251,27 +1442,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_10_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_10_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_10_string = "AND_1";
-      default : _zz_10_string = "?????";
+    case(_zz_14)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
+      default : _zz_14_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_11_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_11_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_11_string = "AND_1";
-      default : _zz_11_string = "?????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_12_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_12_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_12_string = "AND_1";
-      default : _zz_12_string = "?????";
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1283,79 +1474,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_13_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_13_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_13_string = "BITWISE ";
-      default : _zz_13_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14_string = "BITWISE ";
-      default : _zz_14_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15_string = "BITWISE ";
-      default : _zz_15_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : execute_ENV_CTRL_string = "ECALL";
-      default : execute_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_16_string = "ECALL";
-      default : _zz_16_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : execute_BRANCH_CTRL_string = "JALR";
-      default : execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_17)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_17_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_17_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_17_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_17_string = "JALR";
-      default : _zz_17_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_17_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_17_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_17_string = "BITWISE ";
+      default : _zz_17_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_18)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_18_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_18_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_18_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_18_string = "SRA_1    ";
-      default : _zz_18_string = "?????????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_18_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_18_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_18_string = "BITWISE ";
+      default : _zz_18_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
+      default : _zz_19_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1368,12 +1507,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
     case(_zz_21)
       `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
       `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
       `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
       default : _zz_21_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
+      default : _zz_22_string = "???";
     endcase
   end
   always @(*) begin
@@ -1395,35 +1552,61 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
-      default : execute_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_24)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
-      default : _zz_24_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_25)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_25_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_25_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_25_string = "AND_1";
-      default : _zz_25_string = "?????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_ENV_CTRL_string = "ECALL";
+      default : memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_ENV_CTRL_string = "ECALL";
+      default : execute_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1432,6 +1615,15 @@ module VexRiscv (
       `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
       `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
       default : _zz_29_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : execute_BRANCH_CTRL_string = "JALR";
+      default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -1444,28 +1636,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
-      default : _zz_31_string = "?????????";
+    case(execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_32)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_32_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_32_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_32_string = "AND_1";
-      default : _zz_32_string = "?????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_32_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_32_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_32_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_32_string = "SRA_1    ";
+      default : _zz_32_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_33_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_33_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_33_string = "BITWISE ";
-      default : _zz_33_string = "????????";
+    case(execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : execute_SRC2_CTRL_string = "PC ";
+      default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1478,6 +1672,15 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      default : execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_35)
       `Src1CtrlEnum_defaultEncoding_RS : _zz_35_string = "RS          ";
       `Src1CtrlEnum_defaultEncoding_IMU : _zz_35_string = "IMU         ";
@@ -1487,63 +1690,173 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_66)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_66_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_66_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_66_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_66_string = "URS1        ";
-      default : _zz_66_string = "????????????";
+    case(execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_67)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_67_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_67_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_67_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_67_string = "PC ";
-      default : _zz_67_string = "???";
+    case(_zz_36)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_36_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_36_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_36_string = "BITWISE ";
+      default : _zz_36_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_68)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_68_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_68_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_68_string = "BITWISE ";
-      default : _zz_68_string = "????????";
+    case(execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_69)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_69_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_69_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_69_string = "AND_1";
-      default : _zz_69_string = "?????";
+    case(_zz_37)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_37_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_37_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_37_string = "AND_1";
+      default : _zz_37_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_70)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_70_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_70_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_70_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_70_string = "SRA_1    ";
-      default : _zz_70_string = "?????????";
+    case(_zz_41)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_41_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_41_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_41_string = "ECALL";
+      default : _zz_41_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_71)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_71_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_71_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_71_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_71_string = "JALR";
-      default : _zz_71_string = "????";
+    case(_zz_42)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_42_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_42_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_42_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_42_string = "JALR";
+      default : _zz_42_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_72)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_72_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_72_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_72_string = "ECALL";
-      default : _zz_72_string = "?????";
+    case(_zz_43)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_43_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_43_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_43_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_43_string = "SRA_1    ";
+      default : _zz_43_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_44)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_44_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_44_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_44_string = "AND_1";
+      default : _zz_44_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_46)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_46_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_46_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_46_string = "PC ";
+      default : _zz_46_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_47)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_47_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_47_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_47_string = "URS1        ";
+      default : _zz_47_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_78)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_78_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_78_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_78_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_78_string = "URS1        ";
+      default : _zz_78_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_79)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_79_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_79_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_79_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_79_string = "PC ";
+      default : _zz_79_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_80)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_80_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_80_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_80_string = "BITWISE ";
+      default : _zz_80_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_81)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_81_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_81_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_81_string = "AND_1";
+      default : _zz_81_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_82)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_82_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_82_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_82_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_82_string = "SRA_1    ";
+      default : _zz_82_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_83)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_83_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_83_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_83_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_83_string = "JALR";
+      default : _zz_83_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_84)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_84_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_84_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_84_string = "ECALL";
+      default : _zz_84_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1588,101 +1901,163 @@ module VexRiscv (
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
+  always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : execute_to_memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
   `endif
 
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = _zz_100;
+  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+  assign execute_REGFILE_WRITE_DATA = _zz_86;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_SRC2 = _zz_80;
-  assign decode_SRC1 = _zz_75;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign decode_IS_RS2_SIGNED = _zz_155[0];
-  assign decode_IS_RS1_SIGNED = _zz_156[0];
-  assign decode_IS_MUL = _zz_157[0];
-  assign decode_ENV_CTRL = _zz_1;
-  assign _zz_2 = _zz_3;
-  assign decode_IS_CSR = _zz_158[0];
-  assign decode_BRANCH_CTRL = _zz_4;
-  assign _zz_5 = _zz_6;
-  assign decode_SHIFT_CTRL = _zz_7;
-  assign _zz_8 = _zz_9;
-  assign decode_ALU_BITWISE_CTRL = _zz_10;
-  assign _zz_11 = _zz_12;
-  assign decode_SRC_LESS_UNSIGNED = _zz_159[0];
-  assign decode_ALU_CTRL = _zz_13;
-  assign _zz_14 = _zz_15;
-  assign decode_MEMORY_STORE = _zz_160[0];
+  assign decode_IS_RS2_SIGNED = _zz_168[0];
+  assign decode_IS_RS1_SIGNED = _zz_169[0];
+  assign decode_IS_MUL = _zz_170[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_171[0];
+  assign decode_BRANCH_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_SHIFT_CTRL = _zz_11;
+  assign _zz_12 = _zz_13;
+  assign decode_ALU_BITWISE_CTRL = _zz_14;
+  assign _zz_15 = _zz_16;
+  assign decode_SRC_LESS_UNSIGNED = _zz_172[0];
+  assign decode_ALU_CTRL = _zz_17;
+  assign _zz_18 = _zz_19;
+  assign decode_MEMORY_STORE = _zz_173[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_174[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_175[0];
+  assign decode_SRC2_CTRL = _zz_20;
+  assign _zz_21 = _zz_22;
+  assign decode_SRC1_CTRL = _zz_23;
+  assign _zz_24 = _zz_25;
+  assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
+  assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
-  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
+  always @ (*) begin
+    _zz_26 = memory_REGFILE_WRITE_DATA;
+    if(_zz_141)begin
+      _zz_26 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    end
+  end
+
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign execute_ENV_CTRL = _zz_16;
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_88;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
+  assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
+  assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_17;
-  assign decode_RS2_USE = _zz_161[0];
-  assign decode_RS1_USE = _zz_162[0];
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_176[0];
+  assign decode_RS1_USE = _zz_177[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
-  assign execute_SHIFT_CTRL = _zz_18;
+  assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
+  assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
+  assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
+  always @ (*) begin
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_142)begin
+      _zz_31 = _zz_93;
+    end
+    if(_zz_143)begin
+      _zz_31 = execute_CsrPlugin_readData;
+    end
+  end
+
+  assign execute_SHIFT_CTRL = _zz_32;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_19 = decode_PC;
-  assign _zz_20 = decode_RS2;
-  assign decode_SRC2_CTRL = _zz_21;
-  assign _zz_22 = decode_RS1;
-  assign decode_SRC1_CTRL = _zz_23;
-  assign decode_SRC_USE_SUB_LESS = _zz_163[0];
-  assign decode_SRC_ADD_ZERO = _zz_164[0];
+  assign _zz_33 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_34;
+  assign execute_SRC1_CTRL = _zz_35;
+  assign decode_SRC_USE_SUB_LESS = _zz_178[0];
+  assign decode_SRC_ADD_ZERO = _zz_179[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_24;
-  assign execute_SRC2 = decode_to_execute_SRC2;
-  assign execute_SRC1 = decode_to_execute_SRC1;
-  assign execute_ALU_BITWISE_CTRL = _zz_25;
-  assign _zz_26 = execute_INSTRUCTION;
-  assign _zz_27 = execute_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_36;
+  assign execute_SRC2 = _zz_92;
+  assign execute_SRC1 = _zz_87;
+  assign execute_ALU_BITWISE_CTRL = _zz_37;
+  assign _zz_38 = writeBack_INSTRUCTION;
+  assign _zz_39 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_28 = 1'b0;
+    _zz_40 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_28 = 1'b1;
+      _zz_40 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_165[0];
+    decode_REGFILE_WRITE_VALID = _zz_180[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_212) == 32'h00001073),{(_zz_213 == _zz_214),{_zz_215,{_zz_216,_zz_217}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_225) == 32'h00001073),{(_zz_226 == _zz_227),{_zz_228,{_zz_229,_zz_230}}}}}}} != 21'h0);
+  assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_36 = execute_REGFILE_WRITE_DATA;
-    if((execute_arbitration_isValid && execute_MEMORY_ENABLE))begin
-      _zz_36 = execute_DBusSimplePlugin_rspFormated;
-    end
-    if(_zz_131)begin
-      _zz_36 = _zz_81;
-    end
-    if(_zz_132)begin
-      _zz_36 = execute_CsrPlugin_readData;
-    end
-    if(_zz_133)begin
-      _zz_36 = ((execute_INSTRUCTION[13 : 12] == 2'b00) ? execute_MulDivIterativePlugin_accumulator[31 : 0] : execute_MulDivIterativePlugin_accumulator[63 : 32]);
+    _zz_48 = writeBack_REGFILE_WRITE_DATA;
+    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
+      _zz_48 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
-  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
-  assign execute_MEMORY_READ_DATA = dBus_rsp_data;
-  assign execute_REGFILE_WRITE_DATA = _zz_74;
+  assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
+  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
+  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
+  assign memory_MMU_RSP2_physicalAddress = execute_to_memory_MMU_RSP2_physicalAddress;
+  assign memory_MMU_RSP2_isIoAccess = execute_to_memory_MMU_RSP2_isIoAccess;
+  assign memory_MMU_RSP2_isPaging = execute_to_memory_MMU_RSP2_isPaging;
+  assign memory_MMU_RSP2_allowRead = execute_to_memory_MMU_RSP2_allowRead;
+  assign memory_MMU_RSP2_allowWrite = execute_to_memory_MMU_RSP2_allowWrite;
+  assign memory_MMU_RSP2_allowExecute = execute_to_memory_MMU_RSP2_allowExecute;
+  assign memory_MMU_RSP2_exception = execute_to_memory_MMU_RSP2_exception;
+  assign memory_MMU_RSP2_refilling = execute_to_memory_MMU_RSP2_refilling;
+  assign memory_MMU_RSP2_bypassTranslation = execute_to_memory_MMU_RSP2_bypassTranslation;
+  assign memory_PC = execute_to_memory_PC;
+  assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
+  assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MMU_FAULT = ((execute_MMU_RSP2_exception || ((! execute_MMU_RSP2_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP2_allowRead) && (! execute_MEMORY_STORE)));
   assign execute_MMU_RSP2_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
   assign execute_MMU_RSP2_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
@@ -1695,29 +2070,40 @@ module VexRiscv (
   assign execute_MMU_RSP2_bypassTranslation = DBusSimplePlugin_mmuBus_rsp_bypassTranslation;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
+  assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = 1'b0;
-  assign decode_MEMORY_ENABLE = _zz_166[0];
-  assign decode_FLUSH_ALL = _zz_167[0];
+  assign decode_MEMORY_ENABLE = _zz_181[0];
+  assign decode_FLUSH_ALL = _zz_182[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_134)begin
+    if(_zz_144)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_135)begin
+    if(_zz_145)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
+  always @ (*) begin
+    _zz_49 = memory_FORMAL_PC_NEXT;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      _zz_49 = DBusSimplePlugin_redoBranch_payload;
+    end
+    if(BranchPlugin_jumpInterface_valid)begin
+      _zz_49 = BranchPlugin_jumpInterface_payload;
+    end
+  end
+
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
-  assign execute_PC = decode_to_execute_PC;
-  assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
+  assign writeBack_PC = memory_to_writeBack_PC;
+  assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @ (*) begin
     decode_arbitration_haltItself = 1'b0;
     if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
@@ -1727,13 +2113,13 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_82 || _zz_83)))begin
+    if((decode_arbitration_isValid && (_zz_94 || _zz_95)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)) != 1'b0))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -1758,27 +2144,16 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_51)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_MEMORY_STORE)) && ((! dBus_rsp_ready) || (! _zz_51))))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_131)begin
+    if(_zz_142)begin
       if((! execute_LightShifterPlugin_done))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_132)begin
+    if(_zz_143)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(_zz_133)begin
-      if(((! execute_MulDivIterativePlugin_frontendOk) || (! execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-      if(_zz_136)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
@@ -1787,7 +2162,7 @@ module VexRiscv (
   assign execute_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(_zz_137)begin
+    if(CsrPlugin_selfException_valid)begin
       execute_arbitration_removeIt = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -1795,45 +2170,93 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    execute_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      execute_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign execute_arbitration_flushIt = 1'b0;
   always @ (*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(BranchPlugin_jumpInterface_valid)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(_zz_137)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(_zz_138)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(_zz_139)begin
+    if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  assign lastStageInstruction = execute_INSTRUCTION;
-  assign lastStagePc = execute_PC;
-  assign lastStageIsValid = execute_arbitration_isValid;
-  assign lastStageIsFiring = execute_arbitration_isFiring;
+  always @ (*) begin
+    memory_arbitration_haltItself = 1'b0;
+    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+      memory_arbitration_haltItself = 1'b1;
+    end
+    if(_zz_141)begin
+      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+      if(_zz_146)begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+  end
+
+  assign memory_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    memory_arbitration_removeIt = 1'b0;
+    if(DBusSimplePlugin_memoryExceptionPort_valid)begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+    if(memory_arbitration_isFlushed)begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    memory_arbitration_flushIt = 1'b0;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      memory_arbitration_flushIt = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    memory_arbitration_flushNext = 1'b0;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+    if(BranchPlugin_jumpInterface_valid)begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+    if(DBusSimplePlugin_memoryExceptionPort_valid)begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_haltItself = 1'b0;
+  assign writeBack_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    writeBack_arbitration_removeIt = 1'b0;
+    if(writeBack_arbitration_isFlushed)begin
+      writeBack_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_flushIt = 1'b0;
+  always @ (*) begin
+    writeBack_arbitration_flushNext = 1'b0;
+    if(_zz_147)begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(_zz_148)begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign lastStageInstruction = writeBack_INSTRUCTION;
+  assign lastStagePc = writeBack_PC;
+  assign lastStageIsValid = writeBack_arbitration_isValid;
+  assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode} != 2'b00))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_138)begin
+    if(_zz_147)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_139)begin
+    if(_zz_148)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -1849,21 +2272,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_138)begin
+    if(_zz_147)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_139)begin
+    if(_zz_148)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_138)begin
+    if(_zz_147)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_139)begin
-      case(_zz_140)
+    if(_zz_148)begin
+      case(_zz_149)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -1876,13 +2299,13 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({execute_arbitration_flushNext,decode_arbitration_flushNext} != 2'b00);
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != 3'b000);
-  assign _zz_37 = {BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}};
-  assign _zz_38 = (_zz_37 & (~ _zz_168));
-  assign _zz_39 = _zz_38[1];
-  assign _zz_40 = _zz_38[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_130;
+  assign _zz_50 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_51 = (_zz_50 & (~ _zz_183));
+  assign _zz_52 = _zz_51[1];
+  assign _zz_53 = _zz_51[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_140;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -1902,7 +2325,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_170);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_185);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -1942,9 +2365,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_41 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_41);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_41);
+  assign _zz_54 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_54);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_54);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -1953,9 +2376,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_42 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_42);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_42);
+  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_55);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_55);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -1964,22 +2387,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_43 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_43);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_43);
+  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_56);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_56);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_44;
-  assign _zz_44 = ((1'b0 && (! _zz_45)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_45 = _zz_46;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_45;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_57;
+  assign _zz_57 = ((1'b0 && (! _zz_58)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_58 = _zz_59;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_58;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_47)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_47 = _zz_48;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_47;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_49;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_60)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_60 = _zz_61;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_60;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_62;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -1989,6 +2412,8 @@ module VexRiscv (
 
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
@@ -1999,33 +2424,33 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_120 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_121 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_122 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_121;
+  assign _zz_130 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_131 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_132 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_131;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_124 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_125 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_126 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_134 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_135 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_136 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_135)begin
+    if(_zz_145)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_134)begin
+    if(_zz_144)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_127 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_134)begin
-      _zz_127 = 1'b1;
+    _zz_137 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_144)begin
+      _zz_137 = 1'b1;
     end
   end
 
@@ -2033,7 +2458,8 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_119 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_129 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_64 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
@@ -2044,39 +2470,39 @@ module VexRiscv (
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_51));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_52 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_65 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_52 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_65 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_52 = execute_RS2[31 : 0];
+        _zz_65 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_52;
+  assign dBus_cmd_payload_data = _zz_65;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_53 = 4'b0001;
+        _zz_66 = 4'b0001;
       end
       2'b01 : begin
-        _zz_53 = 4'b0011;
+        _zz_66 = 4'b0011;
       end
       default : begin
-        _zz_53 = 4'b1111;
+        _zz_66 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_53 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_66 <<< dBus_cmd_payload_address[1 : 0]);
   assign DBusSimplePlugin_mmuBus_cmd_0_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign DBusSimplePlugin_mmuBus_cmd_0_isStuck = execute_arbitration_isStuck;
   assign DBusSimplePlugin_mmuBus_cmd_0_virtualAddress = execute_SRC_ADD;
@@ -2085,116 +2511,116 @@ module VexRiscv (
   assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(execute_MMU_RSP2_refilling)begin
+    if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end else begin
-      if(execute_MMU_FAULT)begin
+      if(memory_MMU_FAULT)begin
         DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
       end
     end
-    if(_zz_141)begin
+    if(_zz_150)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(! execute_MMU_RSP2_refilling) begin
-      if(execute_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (execute_MEMORY_STORE ? 4'b1111 : 4'b1101);
+    if(! memory_MMU_RSP2_refilling) begin
+      if(memory_MMU_FAULT)begin
+        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 4'b1111 : 4'b1101);
       end
     end
   end
 
-  assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = execute_REGFILE_WRITE_DATA;
+  assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(execute_MMU_RSP2_refilling)begin
+    if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_redoBranch_valid = 1'b1;
     end
-    if(_zz_141)begin
+    if(_zz_150)begin
       DBusSimplePlugin_redoBranch_valid = 1'b0;
     end
   end
 
-  assign DBusSimplePlugin_redoBranch_payload = execute_PC;
+  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
-    execute_DBusSimplePlugin_rspShifted = execute_MEMORY_READ_DATA;
-    case(execute_MEMORY_ADDRESS_LOW)
+    writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
+    case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        execute_DBusSimplePlugin_rspShifted[7 : 0] = execute_MEMORY_READ_DATA[15 : 8];
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[15 : 8];
       end
       2'b10 : begin
-        execute_DBusSimplePlugin_rspShifted[15 : 0] = execute_MEMORY_READ_DATA[31 : 16];
+        writeBack_DBusSimplePlugin_rspShifted[15 : 0] = writeBack_MEMORY_READ_DATA[31 : 16];
       end
       2'b11 : begin
-        execute_DBusSimplePlugin_rspShifted[7 : 0] = execute_MEMORY_READ_DATA[31 : 24];
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_54 = (execute_DBusSimplePlugin_rspShifted[7] && (! execute_INSTRUCTION[14]));
+  assign _zz_67 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_55[31] = _zz_54;
-    _zz_55[30] = _zz_54;
-    _zz_55[29] = _zz_54;
-    _zz_55[28] = _zz_54;
-    _zz_55[27] = _zz_54;
-    _zz_55[26] = _zz_54;
-    _zz_55[25] = _zz_54;
-    _zz_55[24] = _zz_54;
-    _zz_55[23] = _zz_54;
-    _zz_55[22] = _zz_54;
-    _zz_55[21] = _zz_54;
-    _zz_55[20] = _zz_54;
-    _zz_55[19] = _zz_54;
-    _zz_55[18] = _zz_54;
-    _zz_55[17] = _zz_54;
-    _zz_55[16] = _zz_54;
-    _zz_55[15] = _zz_54;
-    _zz_55[14] = _zz_54;
-    _zz_55[13] = _zz_54;
-    _zz_55[12] = _zz_54;
-    _zz_55[11] = _zz_54;
-    _zz_55[10] = _zz_54;
-    _zz_55[9] = _zz_54;
-    _zz_55[8] = _zz_54;
-    _zz_55[7 : 0] = execute_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_68[31] = _zz_67;
+    _zz_68[30] = _zz_67;
+    _zz_68[29] = _zz_67;
+    _zz_68[28] = _zz_67;
+    _zz_68[27] = _zz_67;
+    _zz_68[26] = _zz_67;
+    _zz_68[25] = _zz_67;
+    _zz_68[24] = _zz_67;
+    _zz_68[23] = _zz_67;
+    _zz_68[22] = _zz_67;
+    _zz_68[21] = _zz_67;
+    _zz_68[20] = _zz_67;
+    _zz_68[19] = _zz_67;
+    _zz_68[18] = _zz_67;
+    _zz_68[17] = _zz_67;
+    _zz_68[16] = _zz_67;
+    _zz_68[15] = _zz_67;
+    _zz_68[14] = _zz_67;
+    _zz_68[13] = _zz_67;
+    _zz_68[12] = _zz_67;
+    _zz_68[11] = _zz_67;
+    _zz_68[10] = _zz_67;
+    _zz_68[9] = _zz_67;
+    _zz_68[8] = _zz_67;
+    _zz_68[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_56 = (execute_DBusSimplePlugin_rspShifted[15] && (! execute_INSTRUCTION[14]));
+  assign _zz_69 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_57[31] = _zz_56;
-    _zz_57[30] = _zz_56;
-    _zz_57[29] = _zz_56;
-    _zz_57[28] = _zz_56;
-    _zz_57[27] = _zz_56;
-    _zz_57[26] = _zz_56;
-    _zz_57[25] = _zz_56;
-    _zz_57[24] = _zz_56;
-    _zz_57[23] = _zz_56;
-    _zz_57[22] = _zz_56;
-    _zz_57[21] = _zz_56;
-    _zz_57[20] = _zz_56;
-    _zz_57[19] = _zz_56;
-    _zz_57[18] = _zz_56;
-    _zz_57[17] = _zz_56;
-    _zz_57[16] = _zz_56;
-    _zz_57[15 : 0] = execute_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_70[31] = _zz_69;
+    _zz_70[30] = _zz_69;
+    _zz_70[29] = _zz_69;
+    _zz_70[28] = _zz_69;
+    _zz_70[27] = _zz_69;
+    _zz_70[26] = _zz_69;
+    _zz_70[25] = _zz_69;
+    _zz_70[24] = _zz_69;
+    _zz_70[23] = _zz_69;
+    _zz_70[22] = _zz_69;
+    _zz_70[21] = _zz_69;
+    _zz_70[20] = _zz_69;
+    _zz_70[19] = _zz_69;
+    _zz_70[18] = _zz_69;
+    _zz_70[17] = _zz_69;
+    _zz_70[16] = _zz_69;
+    _zz_70[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_153)
+    case(_zz_166)
       2'b00 : begin
-        execute_DBusSimplePlugin_rspFormated = _zz_55;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_68;
       end
       2'b01 : begin
-        execute_DBusSimplePlugin_rspFormated = _zz_57;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_70;
       end
       default : begin
-        execute_DBusSimplePlugin_rspFormated = execute_DBusSimplePlugin_rspShifted;
+        writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
       end
     endcase
   end
@@ -2217,52 +2643,51 @@ module VexRiscv (
   assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_59 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_60 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_61 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_62 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_63 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_64 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_65 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
-  assign _zz_58 = {(_zz_65 != 1'b0),{({_zz_65,_zz_64} != 2'b00),{(_zz_230 != 1'b0),{(_zz_231 != _zz_232),{_zz_233,{_zz_234,_zz_235}}}}}};
-  assign _zz_66 = _zz_58[2 : 1];
-  assign _zz_35 = _zz_66;
-  assign _zz_67 = _zz_58[7 : 6];
-  assign _zz_34 = _zz_67;
-  assign _zz_68 = _zz_58[14 : 13];
-  assign _zz_33 = _zz_68;
-  assign _zz_69 = _zz_58[17 : 16];
-  assign _zz_32 = _zz_69;
-  assign _zz_70 = _zz_58[20 : 19];
-  assign _zz_31 = _zz_70;
-  assign _zz_71 = _zz_58[23 : 22];
-  assign _zz_30 = _zz_71;
-  assign _zz_72 = _zz_58[26 : 25];
-  assign _zz_29 = _zz_72;
+  assign _zz_72 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_73 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_74 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_75 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_76 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_77 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
+  assign _zz_71 = {(_zz_77 != 1'b0),{({_zz_77,_zz_76} != 2'b00),{(_zz_243 != 1'b0),{(_zz_244 != _zz_245),{_zz_246,{_zz_247,_zz_248}}}}}};
+  assign _zz_78 = _zz_71[2 : 1];
+  assign _zz_47 = _zz_78;
+  assign _zz_79 = _zz_71[7 : 6];
+  assign _zz_46 = _zz_79;
+  assign _zz_80 = _zz_71[14 : 13];
+  assign _zz_45 = _zz_80;
+  assign _zz_81 = _zz_71[17 : 16];
+  assign _zz_44 = _zz_81;
+  assign _zz_82 = _zz_71[20 : 19];
+  assign _zz_43 = _zz_82;
+  assign _zz_83 = _zz_71[23 : 22];
+  assign _zz_42 = _zz_83;
+  assign _zz_84 = _zz_71[26 : 25];
+  assign _zz_41 = _zz_84;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_128;
-  assign decode_RegFilePlugin_rs2Data = _zz_129;
+  assign decode_RegFilePlugin_rs1Data = _zz_138;
+  assign decode_RegFilePlugin_rs2Data = _zz_139;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_27 && execute_arbitration_isFiring);
-    if(_zz_73)begin
+    lastStageRegFileWrite_valid = (_zz_39 && writeBack_arbitration_isFiring);
+    if(_zz_85)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_26[11 : 7];
-    if(_zz_73)begin
+    lastStageRegFileWrite_payload_address = _zz_38[11 : 7];
+    if(_zz_85)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_36;
-    if(_zz_73)begin
+    lastStageRegFileWrite_payload_data = _zz_48;
+    if(_zz_85)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -2284,101 +2709,101 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_74 = execute_IntAluPlugin_bitwise;
+        _zz_86 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_74 = {31'd0, _zz_171};
+        _zz_86 = {31'd0, _zz_186};
       end
       default : begin
-        _zz_74 = execute_SRC_ADD_SUB;
+        _zz_86 = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
   always @ (*) begin
-    case(decode_SRC1_CTRL)
+    case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_75 = _zz_22;
+        _zz_87 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_75 = {29'd0, _zz_172};
+        _zz_87 = {29'd0, _zz_187};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_75 = {decode_INSTRUCTION[31 : 12],12'h0};
+        _zz_87 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_75 = {27'd0, _zz_173};
+        _zz_87 = {27'd0, _zz_188};
       end
     endcase
   end
 
-  assign _zz_76 = _zz_174[11];
+  assign _zz_88 = _zz_189[11];
   always @ (*) begin
-    _zz_77[19] = _zz_76;
-    _zz_77[18] = _zz_76;
-    _zz_77[17] = _zz_76;
-    _zz_77[16] = _zz_76;
-    _zz_77[15] = _zz_76;
-    _zz_77[14] = _zz_76;
-    _zz_77[13] = _zz_76;
-    _zz_77[12] = _zz_76;
-    _zz_77[11] = _zz_76;
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+    _zz_89[19] = _zz_88;
+    _zz_89[18] = _zz_88;
+    _zz_89[17] = _zz_88;
+    _zz_89[16] = _zz_88;
+    _zz_89[15] = _zz_88;
+    _zz_89[14] = _zz_88;
+    _zz_89[13] = _zz_88;
+    _zz_89[12] = _zz_88;
+    _zz_89[11] = _zz_88;
+    _zz_89[10] = _zz_88;
+    _zz_89[9] = _zz_88;
+    _zz_89[8] = _zz_88;
+    _zz_89[7] = _zz_88;
+    _zz_89[6] = _zz_88;
+    _zz_89[5] = _zz_88;
+    _zz_89[4] = _zz_88;
+    _zz_89[3] = _zz_88;
+    _zz_89[2] = _zz_88;
+    _zz_89[1] = _zz_88;
+    _zz_89[0] = _zz_88;
   end
 
-  assign _zz_78 = _zz_175[11];
+  assign _zz_90 = _zz_190[11];
   always @ (*) begin
-    _zz_79[19] = _zz_78;
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+    _zz_91[19] = _zz_90;
+    _zz_91[18] = _zz_90;
+    _zz_91[17] = _zz_90;
+    _zz_91[16] = _zz_90;
+    _zz_91[15] = _zz_90;
+    _zz_91[14] = _zz_90;
+    _zz_91[13] = _zz_90;
+    _zz_91[12] = _zz_90;
+    _zz_91[11] = _zz_90;
+    _zz_91[10] = _zz_90;
+    _zz_91[9] = _zz_90;
+    _zz_91[8] = _zz_90;
+    _zz_91[7] = _zz_90;
+    _zz_91[6] = _zz_90;
+    _zz_91[5] = _zz_90;
+    _zz_91[4] = _zz_90;
+    _zz_91[3] = _zz_90;
+    _zz_91[2] = _zz_90;
+    _zz_91[1] = _zz_90;
+    _zz_91[0] = _zz_90;
   end
 
   always @ (*) begin
-    case(decode_SRC2_CTRL)
+    case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_80 = _zz_20;
+        _zz_92 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_80 = {_zz_77,decode_INSTRUCTION[31 : 20]};
+        _zz_92 = {_zz_89,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_80 = {_zz_79,{decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]}};
+        _zz_92 = {_zz_91,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_80 = _zz_19;
+        _zz_92 = _zz_33;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_176;
+    execute_SrcPlugin_addSub = _zz_191;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -2387,169 +2812,197 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
-  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_shiftReg : execute_SRC1);
+  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   always @ (*) begin
     case(execute_SHIFT_CTRL)
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_81 = (execute_LightShifterPlugin_shiftInput <<< 1);
+        _zz_93 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_81 = _zz_183;
+        _zz_93 = _zz_198;
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_82 = 1'b0;
-    if(_zz_84)begin
-      if((_zz_85 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_82 = 1'b1;
+    _zz_94 = 1'b0;
+    if(_zz_96)begin
+      if((_zz_97 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_94 = 1'b1;
       end
     end
-    if(_zz_142)begin
-      if(_zz_143)begin
+    if(_zz_151)begin
+      if(_zz_152)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_94 = 1'b1;
+        end
+      end
+    end
+    if(_zz_153)begin
+      if(_zz_154)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_94 = 1'b1;
+        end
+      end
+    end
+    if(_zz_155)begin
+      if(_zz_156)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_82 = 1'b1;
+          _zz_94 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_82 = 1'b0;
+      _zz_94 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_83 = 1'b0;
-    if(_zz_84)begin
-      if((_zz_85 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_83 = 1'b1;
+    _zz_95 = 1'b0;
+    if(_zz_96)begin
+      if((_zz_97 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_95 = 1'b1;
       end
     end
-    if(_zz_142)begin
-      if(_zz_143)begin
+    if(_zz_151)begin
+      if(_zz_152)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_95 = 1'b1;
+        end
+      end
+    end
+    if(_zz_153)begin
+      if(_zz_154)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_95 = 1'b1;
+        end
+      end
+    end
+    if(_zz_155)begin
+      if(_zz_156)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_83 = 1'b1;
+          _zz_95 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_83 = 1'b0;
+      _zz_95 = 1'b0;
     end
   end
 
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_86 = execute_INSTRUCTION[14 : 12];
+  assign _zz_98 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_86 == 3'b000)) begin
-        _zz_87 = execute_BranchPlugin_eq;
-    end else if((_zz_86 == 3'b001)) begin
-        _zz_87 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_86 & 3'b101) == 3'b101))) begin
-        _zz_87 = (! execute_SRC_LESS);
+    if((_zz_98 == 3'b000)) begin
+        _zz_99 = execute_BranchPlugin_eq;
+    end else if((_zz_98 == 3'b001)) begin
+        _zz_99 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_98 & 3'b101) == 3'b101))) begin
+        _zz_99 = (! execute_SRC_LESS);
     end else begin
-        _zz_87 = execute_SRC_LESS;
+        _zz_99 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_88 = 1'b0;
+        _zz_100 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_88 = 1'b1;
+        _zz_100 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_88 = 1'b1;
+        _zz_100 = 1'b1;
       end
       default : begin
-        _zz_88 = _zz_87;
+        _zz_100 = _zz_99;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_89 = _zz_185[19];
+  assign _zz_101 = _zz_200[19];
   always @ (*) begin
-    _zz_90[10] = _zz_89;
-    _zz_90[9] = _zz_89;
-    _zz_90[8] = _zz_89;
-    _zz_90[7] = _zz_89;
-    _zz_90[6] = _zz_89;
-    _zz_90[5] = _zz_89;
-    _zz_90[4] = _zz_89;
-    _zz_90[3] = _zz_89;
-    _zz_90[2] = _zz_89;
-    _zz_90[1] = _zz_89;
-    _zz_90[0] = _zz_89;
+    _zz_102[10] = _zz_101;
+    _zz_102[9] = _zz_101;
+    _zz_102[8] = _zz_101;
+    _zz_102[7] = _zz_101;
+    _zz_102[6] = _zz_101;
+    _zz_102[5] = _zz_101;
+    _zz_102[4] = _zz_101;
+    _zz_102[3] = _zz_101;
+    _zz_102[2] = _zz_101;
+    _zz_102[1] = _zz_101;
+    _zz_102[0] = _zz_101;
   end
 
-  assign _zz_91 = _zz_186[11];
+  assign _zz_103 = _zz_201[11];
   always @ (*) begin
-    _zz_92[19] = _zz_91;
-    _zz_92[18] = _zz_91;
-    _zz_92[17] = _zz_91;
-    _zz_92[16] = _zz_91;
-    _zz_92[15] = _zz_91;
-    _zz_92[14] = _zz_91;
-    _zz_92[13] = _zz_91;
-    _zz_92[12] = _zz_91;
-    _zz_92[11] = _zz_91;
-    _zz_92[10] = _zz_91;
-    _zz_92[9] = _zz_91;
-    _zz_92[8] = _zz_91;
-    _zz_92[7] = _zz_91;
-    _zz_92[6] = _zz_91;
-    _zz_92[5] = _zz_91;
-    _zz_92[4] = _zz_91;
-    _zz_92[3] = _zz_91;
-    _zz_92[2] = _zz_91;
-    _zz_92[1] = _zz_91;
-    _zz_92[0] = _zz_91;
+    _zz_104[19] = _zz_103;
+    _zz_104[18] = _zz_103;
+    _zz_104[17] = _zz_103;
+    _zz_104[16] = _zz_103;
+    _zz_104[15] = _zz_103;
+    _zz_104[14] = _zz_103;
+    _zz_104[13] = _zz_103;
+    _zz_104[12] = _zz_103;
+    _zz_104[11] = _zz_103;
+    _zz_104[10] = _zz_103;
+    _zz_104[9] = _zz_103;
+    _zz_104[8] = _zz_103;
+    _zz_104[7] = _zz_103;
+    _zz_104[6] = _zz_103;
+    _zz_104[5] = _zz_103;
+    _zz_104[4] = _zz_103;
+    _zz_104[3] = _zz_103;
+    _zz_104[2] = _zz_103;
+    _zz_104[1] = _zz_103;
+    _zz_104[0] = _zz_103;
   end
 
-  assign _zz_93 = _zz_187[11];
+  assign _zz_105 = _zz_202[11];
   always @ (*) begin
-    _zz_94[18] = _zz_93;
-    _zz_94[17] = _zz_93;
-    _zz_94[16] = _zz_93;
-    _zz_94[15] = _zz_93;
-    _zz_94[14] = _zz_93;
-    _zz_94[13] = _zz_93;
-    _zz_94[12] = _zz_93;
-    _zz_94[11] = _zz_93;
-    _zz_94[10] = _zz_93;
-    _zz_94[9] = _zz_93;
-    _zz_94[8] = _zz_93;
-    _zz_94[7] = _zz_93;
-    _zz_94[6] = _zz_93;
-    _zz_94[5] = _zz_93;
-    _zz_94[4] = _zz_93;
-    _zz_94[3] = _zz_93;
-    _zz_94[2] = _zz_93;
-    _zz_94[1] = _zz_93;
-    _zz_94[0] = _zz_93;
+    _zz_106[18] = _zz_105;
+    _zz_106[17] = _zz_105;
+    _zz_106[16] = _zz_105;
+    _zz_106[15] = _zz_105;
+    _zz_106[14] = _zz_105;
+    _zz_106[13] = _zz_105;
+    _zz_106[12] = _zz_105;
+    _zz_106[11] = _zz_105;
+    _zz_106[10] = _zz_105;
+    _zz_106[9] = _zz_105;
+    _zz_106[8] = _zz_105;
+    _zz_106[7] = _zz_105;
+    _zz_106[6] = _zz_105;
+    _zz_106[5] = _zz_105;
+    _zz_106[4] = _zz_105;
+    _zz_106[3] = _zz_105;
+    _zz_106[2] = _zz_105;
+    _zz_106[1] = _zz_105;
+    _zz_106[0] = _zz_105;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_95 = {{_zz_90,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_107 = {{_zz_102,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_95 = {_zz_92,execute_INSTRUCTION[31 : 20]};
+        _zz_107 = {_zz_104,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_95 = {{_zz_94,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_107 = {{_zz_106,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_95;
+  assign execute_BranchPlugin_branch_src2 = _zz_107;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
-  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
-  assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
+  assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
+  assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   always @ (*) begin
     CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
@@ -2559,13 +3012,11 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_96 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_97 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_98 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_108 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_109 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_110 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_99 = {CsrPlugin_selfException_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_100 = _zz_188[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
     if(decodeExceptionPort_valid)begin
@@ -2578,7 +3029,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(_zz_137)begin
+    if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -2586,14 +3037,33 @@ module VexRiscv (
     end
   end
 
+  always @ (*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+    if(DBusSimplePlugin_memoryExceptionPort_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
+    end
+    if(memory_arbitration_isFlushed)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+    if(writeBack_arbitration_isFlushed)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
+    end
+  end
+
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-  assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && CsrPlugin_allowException);
+  assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
-    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_0;
-    if((CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute != 1'b0))begin
+    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -2639,7 +3109,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = (1'b0 || 1'b0);
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -2687,7 +3157,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_144)begin
+    if(_zz_157)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -2706,14 +3176,14 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_145)begin
+    if(_zz_158)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_145)begin
+    if(_zz_158)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -2728,14 +3198,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_144)begin
+    if(_zz_157)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_144)begin
+    if(_zz_157)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -2744,7 +3214,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_154)
+    case(_zz_167)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -2755,171 +3225,190 @@ module VexRiscv (
   end
 
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
+  assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @ (*) begin
-    execute_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_133)begin
-      if(_zz_136)begin
-        execute_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
+    memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
+    if(_zz_141)begin
+      if(_zz_146)begin
+        memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
   end
 
   always @ (*) begin
-    execute_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! execute_arbitration_isStuck))begin
-      execute_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
+    memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
+    if((! memory_arbitration_isStuck))begin
+      memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
     end
   end
 
-  assign execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (execute_MulDivIterativePlugin_mul_counter_value == 6'h20);
-  assign execute_MulDivIterativePlugin_mul_counter_willOverflow = (execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc && execute_MulDivIterativePlugin_mul_counter_willIncrement);
+  assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
+  assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @ (*) begin
-    if(execute_MulDivIterativePlugin_mul_counter_willOverflow)begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = (execute_MulDivIterativePlugin_mul_counter_value + _zz_191);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_204);
     end
-    if(execute_MulDivIterativePlugin_mul_counter_willClear)begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_101 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_102 = ((execute_IS_MUL && _zz_101) || 1'b0);
+  assign _zz_111 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_112 = ((execute_IS_MUL && _zz_111) || 1'b0);
   always @ (*) begin
-    _zz_103[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_103[31 : 0] = execute_RS1;
+    _zz_113[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_113[31 : 0] = execute_RS1;
   end
 
-  assign _zz_105 = (_zz_104 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_105 != 32'h0);
-  assign _zz_23 = _zz_35;
-  assign _zz_21 = _zz_34;
-  assign _zz_15 = decode_ALU_CTRL;
-  assign _zz_13 = _zz_33;
-  assign _zz_24 = decode_to_execute_ALU_CTRL;
-  assign _zz_12 = decode_ALU_BITWISE_CTRL;
-  assign _zz_10 = _zz_32;
-  assign _zz_25 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_9 = decode_SHIFT_CTRL;
-  assign _zz_7 = _zz_31;
-  assign _zz_18 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_6 = decode_BRANCH_CTRL;
-  assign _zz_4 = _zz_30;
-  assign _zz_17 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_3 = decode_ENV_CTRL;
-  assign _zz_1 = _zz_29;
-  assign _zz_16 = decode_to_execute_ENV_CTRL;
-  assign decode_arbitration_isFlushed = ((execute_arbitration_flushNext != 1'b0) || ({execute_arbitration_flushIt,decode_arbitration_flushIt} != 2'b00));
-  assign execute_arbitration_isFlushed = (1'b0 || (execute_arbitration_flushIt != 1'b0));
-  assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (1'b0 || execute_arbitration_isStuck));
+  assign _zz_115 = (_zz_114 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_115 != 32'h0);
+  assign _zz_25 = decode_SRC1_CTRL;
+  assign _zz_23 = _zz_47;
+  assign _zz_35 = decode_to_execute_SRC1_CTRL;
+  assign _zz_22 = decode_SRC2_CTRL;
+  assign _zz_20 = _zz_46;
+  assign _zz_34 = decode_to_execute_SRC2_CTRL;
+  assign _zz_19 = decode_ALU_CTRL;
+  assign _zz_17 = _zz_45;
+  assign _zz_36 = decode_to_execute_ALU_CTRL;
+  assign _zz_16 = decode_ALU_BITWISE_CTRL;
+  assign _zz_14 = _zz_44;
+  assign _zz_37 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_13 = decode_SHIFT_CTRL;
+  assign _zz_11 = _zz_43;
+  assign _zz_32 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_10 = decode_BRANCH_CTRL;
+  assign _zz_8 = _zz_42;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_41;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
+  assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
   assign decode_arbitration_isFiring = ((decode_arbitration_isValid && (! decode_arbitration_isStuck)) && (! decode_arbitration_removeIt));
-  assign execute_arbitration_isStuckByOthers = (execute_arbitration_haltByOther || 1'b0);
+  assign execute_arbitration_isStuckByOthers = (execute_arbitration_haltByOther || ((1'b0 || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign execute_arbitration_isStuck = (execute_arbitration_haltItself || execute_arbitration_isStuckByOthers);
   assign execute_arbitration_isMoving = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign execute_arbitration_isFiring = ((execute_arbitration_isValid && (! execute_arbitration_isStuck)) && (! execute_arbitration_removeIt));
+  assign memory_arbitration_isStuckByOthers = (memory_arbitration_haltByOther || (1'b0 || writeBack_arbitration_isStuck));
+  assign memory_arbitration_isStuck = (memory_arbitration_haltItself || memory_arbitration_isStuckByOthers);
+  assign memory_arbitration_isMoving = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign memory_arbitration_isFiring = ((memory_arbitration_isValid && (! memory_arbitration_isStuck)) && (! memory_arbitration_removeIt));
+  assign writeBack_arbitration_isStuckByOthers = (writeBack_arbitration_haltByOther || 1'b0);
+  assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
+  assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
+  assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_106 = 32'h0;
+    _zz_116 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_106[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_106[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_106[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_116[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_116[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_116[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_107 = 32'h0;
+    _zz_117 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_107[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_107[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_107[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_117[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_117[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_117[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_108 = 32'h0;
+    _zz_118 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_108[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_108[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_108[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_118[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_118[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_118[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_109 = 32'h0;
+    _zz_119 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_109[31 : 0] = CsrPlugin_mepc;
+      _zz_119[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_110 = 32'h0;
+    _zz_120 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_110[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_110[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_120[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_120[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_111 = 32'h0;
+    _zz_121 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_111[31 : 0] = CsrPlugin_mtval;
+      _zz_121[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_112 = 32'h0;
+    _zz_122 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_112[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_122[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_113 = 32'h0;
+    _zz_123 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_113[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_123[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_114 = 32'h0;
+    _zz_124 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_114[31 : 0] = _zz_104;
+      _zz_124[31 : 0] = _zz_114;
     end
   end
 
   always @ (*) begin
-    _zz_115 = 32'h0;
+    _zz_125 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_115[31 : 0] = _zz_105;
+      _zz_125[31 : 0] = _zz_115;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_106 | _zz_107) | (_zz_108 | _zz_109)) | ((_zz_110 | _zz_111) | (_zz_112 | _zz_113))) | (_zz_114 | _zz_115));
-  assign iBusWishbone_ADR = {_zz_208,_zz_116};
-  assign iBusWishbone_CTI = ((_zz_116 == 3'b111) ? 3'b111 : 3'b010);
+  assign execute_CsrPlugin_readData = ((((_zz_116 | _zz_117) | (_zz_118 | _zz_119)) | ((_zz_120 | _zz_121) | (_zz_122 | _zz_123))) | (_zz_124 | _zz_125));
+  assign iBusWishbone_ADR = {_zz_221,_zz_126};
+  assign iBusWishbone_CTI = ((_zz_126 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_146)begin
+    if(_zz_159)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_146)begin
+    if(_zz_159)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_117;
+  assign iBus_rsp_valid = _zz_127;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -2934,19 +3423,19 @@ module VexRiscv (
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_118 = 4'b0001;
+        _zz_128 = 4'b0001;
       end
       2'b01 : begin
-        _zz_118 = 4'b0011;
+        _zz_128 = 4'b0011;
       end
       default : begin
-        _zz_118 = 4'b1111;
+        _zz_128 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_118 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_128 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
       dBusWishbone_SEL = 4'b1111;
     end
@@ -2966,17 +3455,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_46 <= 1'b0;
-      _zz_48 <= 1'b0;
+      _zz_59 <= 1'b0;
+      _zz_61 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_50;
+      IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      IBusCachedPlugin_rspCounter <= _zz_63;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_51 <= 1'b0;
-      _zz_73 <= 1'b1;
+      _zz_85 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_84 <= 1'b0;
+      _zz_96 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -2985,16 +3475,21 @@ module VexRiscv (
       CsrPlugin_mie_MSIE <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       CsrPlugin_interrupt_valid <= 1'b0;
       CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      execute_MulDivIterativePlugin_frontendOk <= 1'b0;
-      execute_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      _zz_104 <= 32'h0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
+      _zz_114 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
-      _zz_116 <= 3'b000;
-      _zz_117 <= 1'b0;
+      memory_arbitration_isValid <= 1'b0;
+      writeBack_arbitration_isValid <= 1'b0;
+      _zz_126 <= 3'b000;
+      _zz_127 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -3018,16 +3513,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_46 <= 1'b0;
+        _zz_59 <= 1'b0;
       end
-      if(_zz_44)begin
-        _zz_46 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_57)begin
+        _zz_59 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_48 <= 1'b0;
+        _zz_61 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_48 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_61 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3053,18 +3548,50 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      end
+      if((! memory_arbitration_isStuck))begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      end
+      if((! writeBack_arbitration_isStuck))begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      end
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if((dBus_cmd_valid && dBus_cmd_ready))begin
-        _zz_51 <= 1'b1;
-      end
-      if((! execute_arbitration_isStuck))begin
-        _zz_51 <= 1'b0;
-      end
-      _zz_73 <= 1'b0;
-      if(_zz_131)begin
-        if(_zz_147)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_85 <= 1'b0;
+      if(_zz_142)begin
+        if(_zz_160)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3074,7 +3601,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_84 <= (_zz_27 && execute_arbitration_isFiring);
+      _zz_96 <= (_zz_39 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3083,17 +3610,27 @@ module VexRiscv (
       if((! execute_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
-        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+      end
+      if((! memory_arbitration_isStuck))begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+      end
+      if((! writeBack_arbitration_isStuck))begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_148)begin
-        if(_zz_149)begin
+      if(_zz_161)begin
+        if(_zz_162)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_150)begin
+        if(_zz_163)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_151)begin
+        if(_zz_164)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3101,15 +3638,23 @@ module VexRiscv (
         if((! execute_arbitration_isStuck))begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
+        if((! memory_arbitration_isStuck))begin
+          CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
+        end
+        if((! writeBack_arbitration_isStuck))begin
+          CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
+        end
       end
       if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
       if(CsrPlugin_interruptJump)begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_138)begin
+      if(_zz_147)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3120,8 +3665,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_139)begin
-        case(_zz_140)
+      if(_zz_148)begin
+        case(_zz_149)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3131,46 +3676,52 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_98,{_zz_97,_zz_96}} != 3'b000) || CsrPlugin_thirdPartyWake);
-      if(((execute_arbitration_isValid && (! 1'b0)) && (1'b0 || execute_IS_MUL)))begin
-        execute_MulDivIterativePlugin_frontendOk <= 1'b1;
-      end
-      if(execute_arbitration_isMoving)begin
-        execute_MulDivIterativePlugin_frontendOk <= 1'b0;
-      end
-      execute_MulDivIterativePlugin_mul_counter_value <= execute_MulDivIterativePlugin_mul_counter_valueNext;
+      execute_CsrPlugin_wfiWake <= (({_zz_110,{_zz_109,_zz_108}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
       if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
+      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+        memory_arbitration_isValid <= 1'b0;
+      end
+      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+        memory_arbitration_isValid <= execute_arbitration_isValid;
+      end
+      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+        writeBack_arbitration_isValid <= 1'b0;
+      end
+      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+        writeBack_arbitration_isValid <= memory_arbitration_isValid;
+      end
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_202[0];
-          CsrPlugin_mstatus_MIE <= _zz_203[0];
+          CsrPlugin_mstatus_MPIE <= _zz_215[0];
+          CsrPlugin_mstatus_MIE <= _zz_216[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_205[0];
-          CsrPlugin_mie_MTIE <= _zz_206[0];
-          CsrPlugin_mie_MSIE <= _zz_207[0];
+          CsrPlugin_mie_MEIE <= _zz_218[0];
+          CsrPlugin_mie_MTIE <= _zz_219[0];
+          CsrPlugin_mie_MSIE <= _zz_220[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_104 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_114 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_146)begin
+      if(_zz_159)begin
         if(iBusWishbone_ACK)begin
-          _zz_116 <= (_zz_116 + 3'b001);
+          _zz_126 <= (_zz_126 + 3'b001);
         end
       end
-      _zz_117 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_152)begin
+      _zz_127 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_165)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3182,7 +3733,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_49 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_62 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -3190,50 +3741,51 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if((! execute_arbitration_isStuckByOthers))begin
-      execute_LightShifterPlugin_shiftReg <= _zz_36;
-    end
-    if(_zz_131)begin
-      if(_zz_147)begin
+    if(_zz_142)begin
+      if(_zz_160)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_85 <= _zz_26[11 : 7];
+    _zz_97 <= _zz_38[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(execute_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
     if(decodeExceptionPort_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
-    if(_zz_137)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_100 ? DBusSimplePlugin_memoryExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_100 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
+    if(CsrPlugin_selfException_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_148)begin
-      if(_zz_149)begin
+    if(DBusSimplePlugin_memoryExceptionPort_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusSimplePlugin_memoryExceptionPort_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
+    end
+    if(_zz_161)begin
+      if(_zz_162)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_150)begin
+      if(_zz_163)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_151)begin
+      if(_zz_164)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_138)begin
+    if(_zz_147)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= execute_PC;
+          CsrPlugin_mepc <= writeBack_PC;
           if(CsrPlugin_hadException)begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
@@ -3242,26 +3794,47 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_133)begin
-      if(_zz_136)begin
-        execute_MulDivIterativePlugin_rs2 <= (execute_MulDivIterativePlugin_rs2 >>> 1);
-        execute_MulDivIterativePlugin_accumulator <= ({_zz_192,execute_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+    if(_zz_141)begin
+      if(_zz_146)begin
+        memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_205,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
-    if((! execute_MulDivIterativePlugin_frontendOk))begin
-      execute_MulDivIterativePlugin_accumulator <= 65'h0;
-      execute_MulDivIterativePlugin_rs1 <= ((_zz_102 ? (~ _zz_103) : _zz_103) + _zz_199);
-      execute_MulDivIterativePlugin_rs2 <= ((_zz_101 ? (~ execute_RS2) : execute_RS2) + _zz_201);
+    if((! memory_arbitration_isStuck))begin
+      memory_MulDivIterativePlugin_accumulator <= 65'h0;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_112 ? (~ _zz_113) : _zz_113) + _zz_212);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_111 ? (~ execute_RS2) : execute_RS2) + _zz_214);
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if(((! execute_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_execute)))begin
-      decode_to_execute_PC <= _zz_19;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PC <= decode_PC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_PC <= _zz_33;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_24;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -3269,35 +3842,74 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_21;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
+    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_14;
+      decode_to_execute_ALU_CTRL <= _zz_18;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_11;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_8;
+      decode_to_execute_SHIFT_CTRL <= _zz_12;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_5;
+      decode_to_execute_BRANCH_CTRL <= _zz_9;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_2;
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
@@ -3306,25 +3918,54 @@ module VexRiscv (
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= _zz_22;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= _zz_20;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1 <= decode_SRC1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2 <= decode_SRC2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MMU_RSP2_physicalAddress <= execute_MMU_RSP2_physicalAddress;
+      execute_to_memory_MMU_RSP2_isIoAccess <= execute_MMU_RSP2_isIoAccess;
+      execute_to_memory_MMU_RSP2_isPaging <= execute_MMU_RSP2_isPaging;
+      execute_to_memory_MMU_RSP2_allowRead <= execute_MMU_RSP2_allowRead;
+      execute_to_memory_MMU_RSP2_allowWrite <= execute_MMU_RSP2_allowWrite;
+      execute_to_memory_MMU_RSP2_allowExecute <= execute_MMU_RSP2_allowExecute;
+      execute_to_memory_MMU_RSP2_exception <= execute_MMU_RSP2_exception;
+      execute_to_memory_MMU_RSP2_refilling <= execute_MMU_RSP2_refilling;
+      execute_to_memory_MMU_RSP2_bypassTranslation <= execute_MMU_RSP2_bypassTranslation;
+    end
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_26;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -3361,7 +4002,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_204[0];
+        CsrPlugin_mip_MSIP <= _zz_217[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -3376,7 +4017,7 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_152)begin
+    if(_zz_165)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.v
@@ -1,6 +1,6 @@
 // Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
-// Git hash  : 301554ed50130998df7c9b3fa2a900ddbefe2027
+// Git hash  : 43e13174d8583db5f4cd45d2b3515bc206a0010a
 
 
 `define Input2Kind_defaultEncoding_type [0:0]
@@ -86,20 +86,18 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_132;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
-  wire                _zz_139;
-  reg                 _zz_140;
-  reg        [31:0]   _zz_141;
-  reg        [31:0]   _zz_142;
-  reg        [31:0]   _zz_143;
-  reg        [3:0]    _zz_144;
-  reg        [31:0]   _zz_145;
+  wire                _zz_144;
+  wire                _zz_145;
+  wire                _zz_146;
+  wire                _zz_147;
+  wire                _zz_148;
+  wire                _zz_149;
+  wire                _zz_150;
+  wire                _zz_151;
+  reg                 _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [31:0]   _zz_155;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -112,16 +110,6 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_146;
-  wire                _zz_147;
-  wire                _zz_148;
-  wire                _zz_149;
-  wire                _zz_150;
-  wire                _zz_151;
-  wire                _zz_152;
-  wire                _zz_153;
-  wire                _zz_154;
-  wire       [1:0]    _zz_155;
   wire                _zz_156;
   wire                _zz_157;
   wire                _zz_158;
@@ -131,224 +119,255 @@ module VexRiscv (
   wire                _zz_162;
   wire                _zz_163;
   wire                _zz_164;
-  wire                _zz_165;
+  wire       [1:0]    _zz_165;
   wire                _zz_166;
   wire                _zz_167;
-  wire       [1:0]    _zz_168;
+  wire                _zz_168;
   wire                _zz_169;
-  wire       [0:0]    _zz_170;
-  wire       [0:0]    _zz_171;
-  wire       [0:0]    _zz_172;
-  wire       [0:0]    _zz_173;
-  wire       [0:0]    _zz_174;
-  wire       [0:0]    _zz_175;
-  wire       [0:0]    _zz_176;
-  wire       [0:0]    _zz_177;
-  wire       [0:0]    _zz_178;
-  wire       [0:0]    _zz_179;
-  wire       [0:0]    _zz_180;
-  wire       [0:0]    _zz_181;
-  wire       [0:0]    _zz_182;
-  wire       [0:0]    _zz_183;
-  wire       [2:0]    _zz_184;
-  wire       [2:0]    _zz_185;
-  wire       [31:0]   _zz_186;
+  wire                _zz_170;
+  wire                _zz_171;
+  wire                _zz_172;
+  wire                _zz_173;
+  wire                _zz_174;
+  wire                _zz_175;
+  wire                _zz_176;
+  wire                _zz_177;
+  wire                _zz_178;
+  wire                _zz_179;
+  wire                _zz_180;
+  wire                _zz_181;
+  wire                _zz_182;
+  wire       [1:0]    _zz_183;
+  wire                _zz_184;
+  wire       [0:0]    _zz_185;
+  wire       [0:0]    _zz_186;
   wire       [0:0]    _zz_187;
-  wire       [2:0]    _zz_188;
-  wire       [4:0]    _zz_189;
-  wire       [11:0]   _zz_190;
-  wire       [11:0]   _zz_191;
-  wire       [31:0]   _zz_192;
-  wire       [31:0]   _zz_193;
-  wire       [31:0]   _zz_194;
-  wire       [31:0]   _zz_195;
-  wire       [31:0]   _zz_196;
-  wire       [31:0]   _zz_197;
-  wire       [31:0]   _zz_198;
-  wire       [31:0]   _zz_199;
-  wire       [32:0]   _zz_200;
-  wire       [19:0]   _zz_201;
-  wire       [11:0]   _zz_202;
-  wire       [11:0]   _zz_203;
-  wire       [2:0]    _zz_204;
-  wire       [9:0]    _zz_205;
-  wire       [7:0]    _zz_206;
-  wire       [0:0]    _zz_207;
-  wire       [5:0]    _zz_208;
-  wire       [33:0]   _zz_209;
-  wire       [32:0]   _zz_210;
-  wire       [33:0]   _zz_211;
-  wire       [32:0]   _zz_212;
-  wire       [33:0]   _zz_213;
-  wire       [32:0]   _zz_214;
-  wire       [0:0]    _zz_215;
-  wire       [32:0]   _zz_216;
-  wire       [0:0]    _zz_217;
-  wire       [31:0]   _zz_218;
-  wire       [0:0]    _zz_219;
-  wire       [0:0]    _zz_220;
-  wire       [0:0]    _zz_221;
-  wire       [0:0]    _zz_222;
-  wire       [0:0]    _zz_223;
-  wire       [0:0]    _zz_224;
-  wire       [26:0]   _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire       [1:0]    _zz_228;
-  wire       [31:0]   _zz_229;
-  wire       [31:0]   _zz_230;
-  wire       [31:0]   _zz_231;
-  wire                _zz_232;
+  wire       [0:0]    _zz_188;
+  wire       [0:0]    _zz_189;
+  wire       [0:0]    _zz_190;
+  wire       [0:0]    _zz_191;
+  wire       [0:0]    _zz_192;
+  wire       [0:0]    _zz_193;
+  wire       [0:0]    _zz_194;
+  wire       [0:0]    _zz_195;
+  wire       [0:0]    _zz_196;
+  wire       [0:0]    _zz_197;
+  wire       [0:0]    _zz_198;
+  wire       [0:0]    _zz_199;
+  wire       [0:0]    _zz_200;
+  wire       [2:0]    _zz_201;
+  wire       [2:0]    _zz_202;
+  wire       [31:0]   _zz_203;
+  wire       [0:0]    _zz_204;
+  wire       [2:0]    _zz_205;
+  wire       [4:0]    _zz_206;
+  wire       [11:0]   _zz_207;
+  wire       [11:0]   _zz_208;
+  wire       [31:0]   _zz_209;
+  wire       [31:0]   _zz_210;
+  wire       [31:0]   _zz_211;
+  wire       [31:0]   _zz_212;
+  wire       [31:0]   _zz_213;
+  wire       [31:0]   _zz_214;
+  wire       [31:0]   _zz_215;
+  wire       [31:0]   _zz_216;
+  wire       [32:0]   _zz_217;
+  wire       [19:0]   _zz_218;
+  wire       [11:0]   _zz_219;
+  wire       [11:0]   _zz_220;
+  wire       [1:0]    _zz_221;
+  wire       [1:0]    _zz_222;
+  wire       [9:0]    _zz_223;
+  wire       [7:0]    _zz_224;
+  wire       [0:0]    _zz_225;
+  wire       [5:0]    _zz_226;
+  wire       [33:0]   _zz_227;
+  wire       [32:0]   _zz_228;
+  wire       [33:0]   _zz_229;
+  wire       [32:0]   _zz_230;
+  wire       [33:0]   _zz_231;
+  wire       [32:0]   _zz_232;
   wire       [0:0]    _zz_233;
-  wire       [14:0]   _zz_234;
-  wire       [31:0]   _zz_235;
+  wire       [32:0]   _zz_234;
+  wire       [0:0]    _zz_235;
   wire       [31:0]   _zz_236;
-  wire       [31:0]   _zz_237;
-  wire                _zz_238;
+  wire       [0:0]    _zz_237;
+  wire       [0:0]    _zz_238;
   wire       [0:0]    _zz_239;
-  wire       [8:0]    _zz_240;
-  wire       [31:0]   _zz_241;
-  wire       [31:0]   _zz_242;
-  wire       [31:0]   _zz_243;
+  wire       [0:0]    _zz_240;
+  wire       [0:0]    _zz_241;
+  wire       [0:0]    _zz_242;
+  wire       [26:0]   _zz_243;
   wire                _zz_244;
-  wire       [0:0]    _zz_245;
-  wire       [2:0]    _zz_246;
+  wire                _zz_245;
+  wire       [1:0]    _zz_246;
   wire       [31:0]   _zz_247;
   wire       [31:0]   _zz_248;
-  wire       [0:0]    _zz_249;
-  wire       [0:0]    _zz_250;
-  wire                _zz_251;
-  wire       [0:0]    _zz_252;
-  wire       [24:0]   _zz_253;
+  wire       [31:0]   _zz_249;
+  wire                _zz_250;
+  wire       [0:0]    _zz_251;
+  wire       [14:0]   _zz_252;
+  wire       [31:0]   _zz_253;
   wire       [31:0]   _zz_254;
-  wire                _zz_255;
+  wire       [31:0]   _zz_255;
   wire                _zz_256;
   wire       [0:0]    _zz_257;
-  wire       [0:0]    _zz_258;
-  wire       [0:0]    _zz_259;
-  wire       [0:0]    _zz_260;
-  wire                _zz_261;
-  wire       [0:0]    _zz_262;
-  wire       [19:0]   _zz_263;
-  wire       [31:0]   _zz_264;
+  wire       [8:0]    _zz_258;
+  wire       [31:0]   _zz_259;
+  wire       [31:0]   _zz_260;
+  wire       [31:0]   _zz_261;
+  wire                _zz_262;
+  wire       [0:0]    _zz_263;
+  wire       [2:0]    _zz_264;
   wire       [31:0]   _zz_265;
-  wire                _zz_266;
-  wire                _zz_267;
-  wire                _zz_268;
-  wire       [2:0]    _zz_269;
-  wire       [2:0]    _zz_270;
-  wire                _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [16:0]   _zz_273;
-  wire       [31:0]   _zz_274;
-  wire       [31:0]   _zz_275;
-  wire                _zz_276;
-  wire                _zz_277;
-  wire                _zz_278;
-  wire       [0:0]    _zz_279;
+  wire       [31:0]   _zz_266;
+  wire       [0:0]    _zz_267;
+  wire       [0:0]    _zz_268;
+  wire                _zz_269;
+  wire       [0:0]    _zz_270;
+  wire       [24:0]   _zz_271;
+  wire       [31:0]   _zz_272;
+  wire                _zz_273;
+  wire                _zz_274;
+  wire       [0:0]    _zz_275;
+  wire       [0:0]    _zz_276;
+  wire       [0:0]    _zz_277;
+  wire       [0:0]    _zz_278;
+  wire                _zz_279;
   wire       [0:0]    _zz_280;
-  wire                _zz_281;
-  wire       [0:0]    _zz_282;
-  wire       [0:0]    _zz_283;
+  wire       [19:0]   _zz_281;
+  wire       [31:0]   _zz_282;
+  wire       [31:0]   _zz_283;
   wire                _zz_284;
-  wire       [0:0]    _zz_285;
-  wire       [13:0]   _zz_286;
-  wire       [31:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [31:0]   _zz_289;
-  wire       [31:0]   _zz_290;
-  wire       [31:0]   _zz_291;
+  wire                _zz_285;
+  wire                _zz_286;
+  wire       [2:0]    _zz_287;
+  wire       [2:0]    _zz_288;
+  wire                _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [16:0]   _zz_291;
   wire       [31:0]   _zz_292;
   wire       [31:0]   _zz_293;
-  wire       [31:0]   _zz_294;
-  wire       [0:0]    _zz_295;
-  wire       [0:0]    _zz_296;
-  wire       [1:0]    _zz_297;
-  wire       [1:0]    _zz_298;
+  wire                _zz_294;
+  wire                _zz_295;
+  wire                _zz_296;
+  wire       [0:0]    _zz_297;
+  wire       [0:0]    _zz_298;
   wire                _zz_299;
   wire       [0:0]    _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [31:0]   _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
+  wire       [0:0]    _zz_301;
+  wire                _zz_302;
+  wire       [0:0]    _zz_303;
+  wire       [13:0]   _zz_304;
   wire       [31:0]   _zz_305;
   wire       [31:0]   _zz_306;
   wire       [31:0]   _zz_307;
-  wire       [0:0]    _zz_308;
-  wire       [1:0]    _zz_309;
-  wire       [0:0]    _zz_310;
-  wire       [0:0]    _zz_311;
-  wire                _zz_312;
+  wire       [31:0]   _zz_308;
+  wire       [31:0]   _zz_309;
+  wire       [31:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
   wire       [0:0]    _zz_313;
-  wire       [8:0]    _zz_314;
-  wire       [31:0]   _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [31:0]   _zz_317;
-  wire       [31:0]   _zz_318;
-  wire       [31:0]   _zz_319;
-  wire                _zz_320;
-  wire                _zz_321;
-  wire       [5:0]    _zz_322;
-  wire       [5:0]    _zz_323;
-  wire                _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [5:0]    _zz_326;
-  wire                _zz_327;
+  wire       [0:0]    _zz_314;
+  wire       [1:0]    _zz_315;
+  wire       [1:0]    _zz_316;
+  wire                _zz_317;
+  wire       [0:0]    _zz_318;
+  wire       [11:0]   _zz_319;
+  wire       [31:0]   _zz_320;
+  wire       [31:0]   _zz_321;
+  wire       [31:0]   _zz_322;
+  wire       [31:0]   _zz_323;
+  wire       [31:0]   _zz_324;
+  wire       [31:0]   _zz_325;
+  wire       [0:0]    _zz_326;
+  wire       [1:0]    _zz_327;
   wire       [0:0]    _zz_328;
-  wire       [2:0]    _zz_329;
+  wire       [0:0]    _zz_329;
   wire                _zz_330;
   wire       [0:0]    _zz_331;
-  wire       [0:0]    _zz_332;
-  wire       [3:0]    _zz_333;
-  wire       [3:0]    _zz_334;
-  wire                _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [2:0]    _zz_337;
-  wire       [31:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [31:0]   _zz_343;
-  wire       [31:0]   _zz_344;
-  wire       [31:0]   _zz_345;
-  wire                _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [1:0]    _zz_348;
-  wire                _zz_349;
-  wire       [2:0]    _zz_350;
-  wire       [2:0]    _zz_351;
-  wire                _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [0:0]    _zz_354;
-  wire       [31:0]   _zz_355;
-  wire       [31:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [31:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire       [31:0]   _zz_360;
-  wire       [31:0]   _zz_361;
-  wire                _zz_362;
+  wire       [8:0]    _zz_332;
+  wire       [31:0]   _zz_333;
+  wire       [31:0]   _zz_334;
+  wire       [31:0]   _zz_335;
+  wire       [31:0]   _zz_336;
+  wire       [31:0]   _zz_337;
+  wire                _zz_338;
+  wire                _zz_339;
+  wire       [0:0]    _zz_340;
+  wire       [1:0]    _zz_341;
+  wire       [5:0]    _zz_342;
+  wire       [5:0]    _zz_343;
+  wire                _zz_344;
+  wire       [0:0]    _zz_345;
+  wire       [5:0]    _zz_346;
+  wire       [31:0]   _zz_347;
+  wire       [31:0]   _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire                _zz_351;
+  wire       [0:0]    _zz_352;
+  wire       [2:0]    _zz_353;
+  wire                _zz_354;
+  wire       [0:0]    _zz_355;
+  wire       [0:0]    _zz_356;
+  wire       [3:0]    _zz_357;
+  wire       [3:0]    _zz_358;
+  wire                _zz_359;
+  wire       [0:0]    _zz_360;
+  wire       [2:0]    _zz_361;
+  wire       [31:0]   _zz_362;
   wire       [31:0]   _zz_363;
-  wire                _zz_364;
-  wire       [0:0]    _zz_365;
+  wire       [31:0]   _zz_364;
+  wire                _zz_365;
   wire       [0:0]    _zz_366;
   wire       [0:0]    _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [1:0]    _zz_369;
-  wire       [1:0]    _zz_370;
-  wire       [0:0]    _zz_371;
+  wire       [31:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire                _zz_371;
   wire       [0:0]    _zz_372;
-  wire       [31:0]   _zz_373;
-  wire       [31:0]   _zz_374;
-  wire       [31:0]   _zz_375;
-  wire       [31:0]   _zz_376;
-  wire       [31:0]   _zz_377;
-  wire       [31:0]   _zz_378;
+  wire       [1:0]    _zz_373;
+  wire                _zz_374;
+  wire       [2:0]    _zz_375;
+  wire       [2:0]    _zz_376;
+  wire                _zz_377;
+  wire       [0:0]    _zz_378;
+  wire       [0:0]    _zz_379;
+  wire       [31:0]   _zz_380;
+  wire       [31:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire       [31:0]   _zz_384;
+  wire       [31:0]   _zz_385;
+  wire       [31:0]   _zz_386;
+  wire       [31:0]   _zz_387;
+  wire                _zz_388;
+  wire       [31:0]   _zz_389;
+  wire                _zz_390;
+  wire       [0:0]    _zz_391;
+  wire       [0:0]    _zz_392;
+  wire       [0:0]    _zz_393;
+  wire       [0:0]    _zz_394;
+  wire       [1:0]    _zz_395;
+  wire       [1:0]    _zz_396;
+  wire       [0:0]    _zz_397;
+  wire       [0:0]    _zz_398;
+  wire       [31:0]   _zz_399;
+  wire       [31:0]   _zz_400;
+  wire       [31:0]   _zz_401;
+  wire       [31:0]   _zz_402;
+  wire       [31:0]   _zz_403;
+  wire       [31:0]   _zz_404;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                execute_CfuPlugin_CFU_IN_FLIGHT;
+  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
-  wire       [31:0]   decode_SRC2;
-  wire       [31:0]   decode_SRC1;
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
@@ -360,91 +379,136 @@ module VexRiscv (
   wire       `Input2Kind_defaultEncoding_type _zz_2;
   wire       `Input2Kind_defaultEncoding_type _zz_3;
   wire                decode_CfuPlugin_CFU_ENABLE;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10;
   wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_7;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_13;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
   wire                decode_SRC_LESS_UNSIGNED;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_17;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
   wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
+  wire       [31:0]   writeBack_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire                execute_IS_RS1_SIGNED;
-  wire                execute_IS_RS2_SIGNED;
   wire                execute_IS_MUL;
-  wire                execute_CfuPlugin_CFU_IN_FLIGHT;
+  wire                execute_IS_RS2_SIGNED;
+  wire                memory_IS_MUL;
+  reg                 _zz_29;
+  reg                 _zz_30;
+  reg        [31:0]   _zz_31;
+  wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_19;
+  wire       `Input2Kind_defaultEncoding_type _zz_32;
   wire                execute_CfuPlugin_CFU_ENABLE;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
+  wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
+  wire                execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                memory_REGFILE_WRITE_VALID;
+  wire       [31:0]   memory_INSTRUCTION;
+  wire                memory_BYPASSABLE_MEMORY_STAGE;
+  wire                writeBack_REGFILE_WRITE_VALID;
+  reg        [31:0]   _zz_37;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_38;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_23;
-  wire       [31:0]   _zz_24;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_25;
-  wire       [31:0]   _zz_26;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire       [31:0]   _zz_39;
+  wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_40;
+  wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_41;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_42;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_29;
-  wire       [31:0]   _zz_30;
-  wire                _zz_31;
-  reg                 _zz_32;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
+  wire       [31:0]   _zz_44;
+  wire                _zz_45;
+  reg                 _zz_46;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_defaultEncoding_type _zz_33;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_35;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_36;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_37;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_39;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_40;
-  reg        [31:0]   _zz_41;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       [31:0]   execute_MEMORY_READ_DATA;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       `Input2Kind_defaultEncoding_type _zz_47;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_49;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_50;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_53;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_54;
+  wire                writeBack_MEMORY_STORE;
+  reg        [31:0]   _zz_55;
+  wire                writeBack_MEMORY_ENABLE;
+  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   writeBack_MEMORY_READ_DATA;
+  wire                memory_MMU_FAULT;
+  wire       [31:0]   memory_MMU_RSP2_physicalAddress;
+  wire                memory_MMU_RSP2_isIoAccess;
+  wire                memory_MMU_RSP2_isPaging;
+  wire                memory_MMU_RSP2_allowRead;
+  wire                memory_MMU_RSP2_allowWrite;
+  wire                memory_MMU_RSP2_allowExecute;
+  wire                memory_MMU_RSP2_exception;
+  wire                memory_MMU_RSP2_refilling;
+  wire                memory_MMU_RSP2_bypassTranslation;
+  wire       [31:0]   memory_PC;
+  wire       [31:0]   memory_REGFILE_WRITE_DATA;
+  wire                memory_MEMORY_STORE;
+  wire                memory_MEMORY_ENABLE;
   wire                execute_MMU_FAULT;
   wire       [31:0]   execute_MMU_RSP2_physicalAddress;
   wire                execute_MMU_RSP2_isIoAccess;
@@ -457,6 +521,7 @@ module VexRiscv (
   wire                execute_MMU_RSP2_bypassTranslation;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
+  wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
@@ -465,9 +530,11 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
+  reg        [31:0]   _zz_56;
+  reg        [31:0]   _zz_57;
   wire       [31:0]   decode_PC;
-  wire       [31:0]   execute_PC;
-  wire       [31:0]   execute_INSTRUCTION;
+  wire       [31:0]   writeBack_PC;
+  wire       [31:0]   writeBack_INSTRUCTION;
   reg                 decode_arbitration_haltItself;
   reg                 decode_arbitration_haltByOther;
   reg                 decode_arbitration_removeIt;
@@ -482,7 +549,7 @@ module VexRiscv (
   reg                 execute_arbitration_haltItself;
   wire                execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
-  reg                 execute_arbitration_flushIt;
+  wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
   reg                 execute_arbitration_isValid;
   wire                execute_arbitration_isStuck;
@@ -490,6 +557,28 @@ module VexRiscv (
   wire                execute_arbitration_isFlushed;
   wire                execute_arbitration_isMoving;
   wire                execute_arbitration_isFiring;
+  reg                 memory_arbitration_haltItself;
+  wire                memory_arbitration_haltByOther;
+  reg                 memory_arbitration_removeIt;
+  reg                 memory_arbitration_flushIt;
+  reg                 memory_arbitration_flushNext;
+  reg                 memory_arbitration_isValid;
+  wire                memory_arbitration_isStuck;
+  wire                memory_arbitration_isStuckByOthers;
+  wire                memory_arbitration_isFlushed;
+  wire                memory_arbitration_isMoving;
+  wire                memory_arbitration_isFiring;
+  wire                writeBack_arbitration_haltItself;
+  wire                writeBack_arbitration_haltByOther;
+  reg                 writeBack_arbitration_removeIt;
+  wire                writeBack_arbitration_flushIt;
+  reg                 writeBack_arbitration_flushNext;
+  reg                 writeBack_arbitration_isValid;
+  wire                writeBack_arbitration_isStuck;
+  wire                writeBack_arbitration_isStuckByOthers;
+  wire                writeBack_arbitration_isFlushed;
+  wire                writeBack_arbitration_isMoving;
+  wire                writeBack_arbitration_isFiring;
   wire       [31:0]   lastStageInstruction /* verilator public */ ;
   wire       [31:0]   lastStagePc /* verilator public */ ;
   wire                lastStageIsValid /* verilator public */ ;
@@ -498,6 +587,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_pcValids_0;
   wire                IBusCachedPlugin_pcValids_1;
+  wire                IBusCachedPlugin_pcValids_2;
+  wire                IBusCachedPlugin_pcValids_3;
   wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
   wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
   wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
@@ -544,6 +635,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_jumpInterface_payload;
   wire                CsrPlugin_exceptionPendings_0;
   wire                CsrPlugin_exceptionPendings_1;
+  wire                CsrPlugin_exceptionPendings_2;
+  wire                CsrPlugin_exceptionPendings_3;
   wire                externalInterrupt;
   wire                contextSwitching;
   reg        [1:0]    CsrPlugin_privilege;
@@ -559,10 +652,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_42;
-  wire       [2:0]    _zz_43;
-  wire                _zz_44;
-  wire                _zz_45;
+  wire       [2:0]    _zz_58;
+  wire       [2:0]    _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -599,16 +692,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_46;
-  wire                _zz_47;
-  wire                _zz_48;
+  wire                _zz_62;
+  wire                _zz_63;
+  wire                _zz_64;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_49;
-  wire                _zz_50;
-  reg                 _zz_51;
-  wire                _zz_52;
-  reg                 _zz_53;
-  reg        [31:0]   _zz_54;
+  wire                _zz_65;
+  wire                _zz_66;
+  reg                 _zz_67;
+  wire                _zz_68;
+  reg                 _zz_69;
+  reg        [31:0]   _zz_70;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -619,6 +712,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -626,7 +721,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_55;
+  wire       [31:0]   _zz_71;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -643,34 +738,33 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  reg                 _zz_56;
+  wire                _zz_72;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_57;
-  reg        [3:0]    _zz_58;
+  reg        [31:0]   _zz_73;
+  reg        [3:0]    _zz_74;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  reg        [31:0]   execute_DBusSimplePlugin_rspShifted;
-  wire                _zz_59;
-  reg        [31:0]   _zz_60;
-  wire                _zz_61;
-  reg        [31:0]   _zz_62;
-  reg        [31:0]   execute_DBusSimplePlugin_rspFormated;
-  wire       [31:0]   _zz_63;
-  wire                _zz_64;
-  wire                _zz_65;
-  wire                _zz_66;
-  wire                _zz_67;
-  wire                _zz_68;
-  wire                _zz_69;
-  wire                _zz_70;
-  wire                _zz_71;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_72;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_73;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_74;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_75;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_76;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_77;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_78;
-  wire       `Input2Kind_defaultEncoding_type _zz_79;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
+  wire                _zz_75;
+  reg        [31:0]   _zz_76;
+  wire                _zz_77;
+  reg        [31:0]   _zz_78;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
+  wire       [31:0]   _zz_79;
+  wire                _zz_80;
+  wire                _zz_81;
+  wire                _zz_82;
+  wire                _zz_83;
+  wire                _zz_84;
+  wire                _zz_85;
+  wire                _zz_86;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_87;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_88;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_89;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_90;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_91;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_92;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_93;
+  wire       `Input2Kind_defaultEncoding_type _zz_94;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -678,41 +772,40 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_80;
+  reg                 _zz_95;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_81;
-  reg        [31:0]   _zz_82;
-  wire                _zz_83;
-  reg        [19:0]   _zz_84;
-  wire                _zz_85;
-  reg        [19:0]   _zz_86;
-  reg        [31:0]   _zz_87;
+  reg        [31:0]   _zz_96;
+  reg        [31:0]   _zz_97;
+  wire                _zz_98;
+  reg        [19:0]   _zz_99;
+  wire                _zz_100;
+  reg        [19:0]   _zz_101;
+  reg        [31:0]   _zz_102;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
   wire                execute_LightShifterPlugin_isShift;
   reg        [4:0]    execute_LightShifterPlugin_amplitudeReg;
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
-  reg        [31:0]   execute_LightShifterPlugin_shiftReg;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_88;
-  reg                 _zz_89;
-  reg                 _zz_90;
-  reg                 _zz_91;
-  reg        [4:0]    _zz_92;
+  reg        [31:0]   _zz_103;
+  reg                 _zz_104;
+  reg                 _zz_105;
+  reg                 _zz_106;
+  reg        [4:0]    _zz_107;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
+  wire       [2:0]    _zz_108;
+  reg                 _zz_109;
+  reg                 _zz_110;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_96;
-  reg        [10:0]   _zz_97;
-  wire                _zz_98;
-  reg        [19:0]   _zz_99;
-  wire                _zz_100;
-  reg        [18:0]   _zz_101;
-  reg        [31:0]   _zz_102;
+  wire                _zz_111;
+  reg        [10:0]   _zz_112;
+  wire                _zz_113;
+  reg        [19:0]   _zz_114;
+  wire                _zz_115;
+  reg        [18:0]   _zz_116;
+  reg        [31:0]   _zz_117;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -734,28 +827,31 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_103;
-  wire                _zz_104;
-  wire                _zz_105;
+  wire                _zz_118;
+  wire                _zz_119;
+  wire                _zz_120;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [2:0]    _zz_106;
-  wire       [2:0]    _zz_107;
-  wire                _zz_108;
-  wire                _zz_109;
-  wire       [1:0]    _zz_110;
+  wire       [1:0]    _zz_121;
+  wire                _zz_122;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_1;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
@@ -780,36 +876,56 @@ module VexRiscv (
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
-  wire                _zz_111;
-  reg        [23:0]   _zz_112;
-  reg        [31:0]   _zz_113;
-  wire                execute_CfuPlugin_rsp_valid;
-  reg                 execute_CfuPlugin_rsp_ready;
-  wire                execute_CfuPlugin_rsp_payload_response_ok;
-  wire       [31:0]   execute_CfuPlugin_rsp_payload_outputs_0;
-  reg        [32:0]   execute_MulDivIterativePlugin_rs1;
-  reg        [31:0]   execute_MulDivIterativePlugin_rs2;
-  reg        [64:0]   execute_MulDivIterativePlugin_accumulator;
-  reg                 execute_MulDivIterativePlugin_frontendOk;
-  reg                 execute_MulDivIterativePlugin_mul_counter_willIncrement;
-  reg                 execute_MulDivIterativePlugin_mul_counter_willClear;
-  reg        [5:0]    execute_MulDivIterativePlugin_mul_counter_valueNext;
-  reg        [5:0]    execute_MulDivIterativePlugin_mul_counter_value;
-  wire                execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
-  wire                execute_MulDivIterativePlugin_mul_counter_willOverflow;
-  wire                _zz_114;
-  wire                _zz_115;
-  reg        [32:0]   _zz_116;
+  wire                _zz_123;
+  reg        [23:0]   _zz_124;
+  reg        [31:0]   _zz_125;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire                memory_CfuPlugin_rsp_payload_response_ok;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
+  reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
+  reg        [32:0]   memory_MulDivIterativePlugin_rs1;
+  reg        [31:0]   memory_MulDivIterativePlugin_rs2;
+  reg        [64:0]   memory_MulDivIterativePlugin_accumulator;
+  wire                memory_MulDivIterativePlugin_frontendOk;
+  reg                 memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  reg                 memory_MulDivIterativePlugin_mul_counter_willClear;
+  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_valueNext;
+  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
+  wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
+  wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
+  wire                _zz_126;
+  wire                _zz_127;
+  reg        [32:0]   _zz_128;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_117;
-  wire       [31:0]   _zz_118;
+  reg        [31:0]   _zz_129;
+  wire       [31:0]   _zz_130;
   reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_STORE;
+  reg                 execute_to_memory_MEMORY_STORE;
+  reg                 memory_to_writeBack_MEMORY_STORE;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
@@ -817,18 +933,36 @@ module VexRiscv (
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
   reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
   reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_SRC1;
-  reg        [31:0]   decode_to_execute_SRC2;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_MMU_FAULT;
+  reg        [31:0]   execute_to_memory_MMU_RSP2_physicalAddress;
+  reg                 execute_to_memory_MMU_RSP2_isIoAccess;
+  reg                 execute_to_memory_MMU_RSP2_isPaging;
+  reg                 execute_to_memory_MMU_RSP2_allowRead;
+  reg                 execute_to_memory_MMU_RSP2_allowWrite;
+  reg                 execute_to_memory_MMU_RSP2_allowExecute;
+  reg                 execute_to_memory_MMU_RSP2_exception;
+  reg                 execute_to_memory_MMU_RSP2_refilling;
+  reg                 execute_to_memory_MMU_RSP2_bypassTranslation;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -840,18 +974,18 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_2944;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_119;
-  reg        [31:0]   _zz_120;
-  reg        [31:0]   _zz_121;
-  reg        [31:0]   _zz_122;
-  reg        [31:0]   _zz_123;
-  reg        [31:0]   _zz_124;
-  reg        [31:0]   _zz_125;
-  reg        [31:0]   _zz_126;
-  reg        [31:0]   _zz_127;
-  reg        [31:0]   _zz_128;
-  reg        [2:0]    _zz_129;
-  reg                 _zz_130;
+  reg        [31:0]   _zz_131;
+  reg        [31:0]   _zz_132;
+  reg        [31:0]   _zz_133;
+  reg        [31:0]   _zz_134;
+  reg        [31:0]   _zz_135;
+  reg        [31:0]   _zz_136;
+  reg        [31:0]   _zz_137;
+  reg        [31:0]   _zz_138;
+  reg        [31:0]   _zz_139;
+  reg        [31:0]   _zz_140;
+  reg        [2:0]    _zz_141;
+  reg                 _zz_142;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -865,333 +999,369 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_131;
+  reg        [3:0]    _zz_143;
   `ifndef SYNTHESIS
   reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] _zz_1_string;
   reg [39:0] _zz_2_string;
   reg [39:0] _zz_3_string;
-  reg [39:0] decode_ENV_CTRL_string;
   reg [39:0] _zz_4_string;
   reg [39:0] _zz_5_string;
   reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [39:0] decode_ENV_CTRL_string;
+  reg [39:0] _zz_8_string;
+  reg [39:0] _zz_9_string;
+  reg [39:0] _zz_10_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
+  reg [31:0] _zz_11_string;
+  reg [31:0] _zz_12_string;
+  reg [31:0] _zz_13_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_14_string;
+  reg [71:0] _zz_15_string;
+  reg [71:0] _zz_16_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_13_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_16_string;
-  reg [63:0] _zz_17_string;
-  reg [63:0] _zz_18_string;
-  reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_18_string;
   reg [39:0] _zz_19_string;
-  reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_20_string;
-  reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_21_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_22_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
   reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_23_string;
+  reg [23:0] _zz_24_string;
   reg [23:0] _zz_25_string;
   reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_26_string;
   reg [95:0] _zz_27_string;
-  reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_28_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [95:0] _zz_28_string;
+  reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_32_string;
+  reg [39:0] memory_ENV_CTRL_string;
   reg [39:0] _zz_33_string;
+  reg [39:0] execute_ENV_CTRL_string;
   reg [39:0] _zz_34_string;
-  reg [31:0] _zz_35_string;
-  reg [71:0] _zz_36_string;
-  reg [39:0] _zz_37_string;
-  reg [63:0] _zz_38_string;
-  reg [23:0] _zz_39_string;
-  reg [95:0] _zz_40_string;
-  reg [95:0] _zz_72_string;
-  reg [23:0] _zz_73_string;
-  reg [63:0] _zz_74_string;
-  reg [39:0] _zz_75_string;
-  reg [71:0] _zz_76_string;
-  reg [31:0] _zz_77_string;
-  reg [39:0] _zz_78_string;
-  reg [39:0] _zz_79_string;
+  reg [39:0] writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_35_string;
+  reg [31:0] execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_36_string;
+  reg [71:0] execute_SHIFT_CTRL_string;
+  reg [71:0] _zz_38_string;
+  reg [23:0] execute_SRC2_CTRL_string;
+  reg [23:0] _zz_40_string;
+  reg [95:0] execute_SRC1_CTRL_string;
+  reg [95:0] _zz_41_string;
+  reg [63:0] execute_ALU_CTRL_string;
+  reg [63:0] _zz_42_string;
+  reg [39:0] execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_43_string;
+  reg [39:0] _zz_47_string;
+  reg [39:0] _zz_48_string;
+  reg [31:0] _zz_49_string;
+  reg [71:0] _zz_50_string;
+  reg [39:0] _zz_51_string;
+  reg [63:0] _zz_52_string;
+  reg [23:0] _zz_53_string;
+  reg [95:0] _zz_54_string;
+  reg [95:0] _zz_87_string;
+  reg [23:0] _zz_88_string;
+  reg [63:0] _zz_89_string;
+  reg [39:0] _zz_90_string;
+  reg [71:0] _zz_91_string;
+  reg [31:0] _zz_92_string;
+  reg [39:0] _zz_93_string;
+  reg [39:0] _zz_94_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
+  reg [39:0] execute_to_memory_ENV_CTRL_string;
+  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_146 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_147 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_148 = (execute_arbitration_isValid && execute_IS_MUL);
-  assign _zz_149 = ((_zz_137 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_150 = ((_zz_137 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_151 = (execute_MulDivIterativePlugin_frontendOk && (! execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_152 = ({CfuPlugin_joinException_valid,{CsrPlugin_selfException_valid,DBusSimplePlugin_memoryExceptionPort_valid}} != 3'b000);
-  assign _zz_153 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_154 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_155 = execute_INSTRUCTION[29 : 28];
-  assign _zz_156 = (! ((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (1'b0 || (! execute_arbitration_isStuckByOthers))));
-  assign _zz_157 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_158 = (1'b1 || (! 1'b1));
-  assign _zz_159 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_160 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_161 = (iBus_cmd_valid || (_zz_129 != 3'b000));
-  assign _zz_162 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_163 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_164 = ((_zz_103 && 1'b1) && (! 1'b0));
-  assign _zz_165 = ((_zz_104 && 1'b1) && (! 1'b0));
-  assign _zz_166 = ((_zz_105 && 1'b1) && (! 1'b0));
-  assign _zz_167 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_168 = execute_INSTRUCTION[13 : 12];
-  assign _zz_169 = execute_INSTRUCTION[13];
-  assign _zz_170 = _zz_63[31 : 31];
-  assign _zz_171 = _zz_63[30 : 30];
-  assign _zz_172 = _zz_63[29 : 29];
-  assign _zz_173 = _zz_63[27 : 27];
-  assign _zz_174 = _zz_63[24 : 24];
-  assign _zz_175 = _zz_63[15 : 15];
-  assign _zz_176 = _zz_63[11 : 11];
-  assign _zz_177 = _zz_63[12 : 12];
-  assign _zz_178 = _zz_63[5 : 5];
-  assign _zz_179 = _zz_63[3 : 3];
-  assign _zz_180 = _zz_63[18 : 18];
-  assign _zz_181 = _zz_63[8 : 8];
-  assign _zz_182 = _zz_63[4 : 4];
-  assign _zz_183 = _zz_63[0 : 0];
-  assign _zz_184 = (_zz_42 - 3'b001);
-  assign _zz_185 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_186 = {29'd0, _zz_185};
-  assign _zz_187 = execute_SRC_LESS;
-  assign _zz_188 = 3'b100;
-  assign _zz_189 = decode_INSTRUCTION[19 : 15];
-  assign _zz_190 = decode_INSTRUCTION[31 : 20];
-  assign _zz_191 = {decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]};
-  assign _zz_192 = ($signed(_zz_193) + $signed(_zz_196));
-  assign _zz_193 = ($signed(_zz_194) + $signed(_zz_195));
-  assign _zz_194 = execute_SRC1;
-  assign _zz_195 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_196 = (execute_SRC_USE_SUB_LESS ? _zz_197 : _zz_198);
-  assign _zz_197 = 32'h00000001;
-  assign _zz_198 = 32'h0;
-  assign _zz_199 = (_zz_200 >>> 1);
-  assign _zz_200 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_201 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_202 = execute_INSTRUCTION[31 : 20];
-  assign _zz_203 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_204 = (_zz_106 - 3'b001);
-  assign _zz_205 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_206 = execute_INSTRUCTION[31 : 24];
-  assign _zz_207 = execute_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_208 = {5'd0, _zz_207};
-  assign _zz_209 = (_zz_211 + _zz_213);
-  assign _zz_210 = (execute_MulDivIterativePlugin_rs2[0] ? execute_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_211 = {{1{_zz_210[32]}}, _zz_210};
-  assign _zz_212 = _zz_214;
-  assign _zz_213 = {{1{_zz_212[32]}}, _zz_212};
-  assign _zz_214 = (execute_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_215 = _zz_115;
-  assign _zz_216 = {32'd0, _zz_215};
-  assign _zz_217 = _zz_114;
-  assign _zz_218 = {31'd0, _zz_217};
-  assign _zz_219 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_220 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_221 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_222 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_223 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_224 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_225 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_226 = 1'b1;
-  assign _zz_227 = 1'b1;
-  assign _zz_228 = {_zz_45,_zz_44};
-  assign _zz_229 = 32'h0000106f;
-  assign _zz_230 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_231 = 32'h00001073;
-  assign _zz_232 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_233 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_234 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_235) == 32'h00000003),{(_zz_236 == _zz_237),{_zz_238,{_zz_239,_zz_240}}}}}};
-  assign _zz_235 = 32'h0000207f;
-  assign _zz_236 = (decode_INSTRUCTION & 32'h0000505f);
-  assign _zz_237 = 32'h00000003;
-  assign _zz_238 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
-  assign _zz_239 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_240 = {((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033),{((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & _zz_241) == 32'h00005013),{(_zz_242 == _zz_243),{_zz_244,{_zz_245,_zz_246}}}}}};
-  assign _zz_241 = 32'hbc00707f;
-  assign _zz_242 = (decode_INSTRUCTION & 32'hfc00705f);
-  assign _zz_243 = 32'h00001013;
-  assign _zz_244 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_245 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_246 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
-  assign _zz_247 = (decode_INSTRUCTION & 32'h02000074);
-  assign _zz_248 = 32'h02000030;
-  assign _zz_249 = _zz_69;
-  assign _zz_250 = 1'b0;
-  assign _zz_251 = (((decode_INSTRUCTION & 32'h10003050) == 32'h00000050) != 1'b0);
-  assign _zz_252 = (((decode_INSTRUCTION & _zz_254) == 32'h10000050) != 1'b0);
-  assign _zz_253 = {({_zz_255,_zz_256} != 2'b00),{({_zz_257,_zz_258} != 2'b00),{(_zz_259 != _zz_260),{_zz_261,{_zz_262,_zz_263}}}}};
-  assign _zz_254 = 32'h10403050;
-  assign _zz_255 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_256 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_257 = _zz_68;
-  assign _zz_258 = ((decode_INSTRUCTION & _zz_264) == 32'h00000004);
-  assign _zz_259 = ((decode_INSTRUCTION & _zz_265) == 32'h00000040);
-  assign _zz_260 = 1'b0;
-  assign _zz_261 = ({_zz_266,_zz_267} != 2'b00);
-  assign _zz_262 = (_zz_268 != 1'b0);
-  assign _zz_263 = {(_zz_269 != _zz_270),{_zz_271,{_zz_272,_zz_273}}};
-  assign _zz_264 = 32'h0000001c;
-  assign _zz_265 = 32'h00000058;
-  assign _zz_266 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_267 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz_268 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
-  assign _zz_269 = {(_zz_274 == _zz_275),{_zz_276,_zz_277}};
-  assign _zz_270 = 3'b000;
-  assign _zz_271 = ({_zz_278,{_zz_279,_zz_280}} != 3'b000);
-  assign _zz_272 = (_zz_281 != 1'b0);
-  assign _zz_273 = {(_zz_282 != _zz_283),{_zz_284,{_zz_285,_zz_286}}};
-  assign _zz_274 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_275 = 32'h40001010;
-  assign _zz_276 = ((decode_INSTRUCTION & _zz_287) == 32'h00001010);
-  assign _zz_277 = ((decode_INSTRUCTION & _zz_288) == 32'h00001010);
-  assign _zz_278 = ((decode_INSTRUCTION & _zz_289) == 32'h00000024);
-  assign _zz_279 = (_zz_290 == _zz_291);
-  assign _zz_280 = (_zz_292 == _zz_293);
-  assign _zz_281 = ((decode_INSTRUCTION & _zz_294) == 32'h00001000);
-  assign _zz_282 = _zz_70;
-  assign _zz_283 = 1'b0;
-  assign _zz_284 = ({_zz_295,_zz_296} != 2'b00);
-  assign _zz_285 = (_zz_297 != _zz_298);
-  assign _zz_286 = {_zz_299,{_zz_300,_zz_301}};
-  assign _zz_287 = 32'h00007034;
-  assign _zz_288 = 32'h02007054;
-  assign _zz_289 = 32'h00000064;
-  assign _zz_290 = (decode_INSTRUCTION & 32'h00003034);
-  assign _zz_291 = 32'h00001010;
-  assign _zz_292 = (decode_INSTRUCTION & 32'h02003054);
-  assign _zz_293 = 32'h00001010;
-  assign _zz_294 = 32'h00001000;
-  assign _zz_295 = ((decode_INSTRUCTION & _zz_302) == 32'h00002000);
-  assign _zz_296 = ((decode_INSTRUCTION & _zz_303) == 32'h00001000);
-  assign _zz_297 = {(_zz_304 == _zz_305),(_zz_306 == _zz_307)};
-  assign _zz_298 = 2'b00;
-  assign _zz_299 = (_zz_65 != 1'b0);
-  assign _zz_300 = ({_zz_308,_zz_309} != 3'b000);
-  assign _zz_301 = {(_zz_310 != _zz_311),{_zz_312,{_zz_313,_zz_314}}};
-  assign _zz_302 = 32'h00002010;
-  assign _zz_303 = 32'h00005000;
-  assign _zz_304 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_305 = 32'h00006000;
-  assign _zz_306 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_307 = 32'h00004000;
-  assign _zz_308 = _zz_69;
-  assign _zz_309 = {(_zz_315 == _zz_316),(_zz_317 == _zz_318)};
-  assign _zz_310 = ((decode_INSTRUCTION & _zz_319) == 32'h00000020);
-  assign _zz_311 = 1'b0;
-  assign _zz_312 = ({_zz_320,_zz_321} != 2'b00);
-  assign _zz_313 = (_zz_67 != 1'b0);
-  assign _zz_314 = {(_zz_322 != _zz_323),{_zz_324,{_zz_325,_zz_326}}};
-  assign _zz_315 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_316 = 32'h00000020;
-  assign _zz_317 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_318 = 32'h00000020;
-  assign _zz_319 = 32'h00000020;
-  assign _zz_320 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
-  assign _zz_321 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz_322 = {_zz_68,{_zz_327,{_zz_328,_zz_329}}};
-  assign _zz_323 = 6'h0;
-  assign _zz_324 = ({_zz_66,_zz_330} != 2'b00);
-  assign _zz_325 = ({_zz_331,_zz_332} != 2'b00);
-  assign _zz_326 = {(_zz_333 != _zz_334),{_zz_335,{_zz_336,_zz_337}}};
-  assign _zz_327 = ((decode_INSTRUCTION & _zz_338) == 32'h00001010);
-  assign _zz_328 = (_zz_339 == _zz_340);
-  assign _zz_329 = {_zz_67,{_zz_341,_zz_342}};
-  assign _zz_330 = ((decode_INSTRUCTION & _zz_343) == 32'h00000020);
-  assign _zz_331 = _zz_66;
-  assign _zz_332 = (_zz_344 == _zz_345);
-  assign _zz_333 = {_zz_346,{_zz_347,_zz_348}};
-  assign _zz_334 = 4'b0000;
-  assign _zz_335 = (_zz_349 != 1'b0);
-  assign _zz_336 = (_zz_350 != _zz_351);
-  assign _zz_337 = {_zz_352,{_zz_353,_zz_354}};
-  assign _zz_338 = 32'h00001010;
-  assign _zz_339 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_340 = 32'h00002010;
-  assign _zz_341 = (_zz_355 == _zz_356);
-  assign _zz_342 = (_zz_357 == _zz_358);
-  assign _zz_343 = 32'h00000070;
-  assign _zz_344 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_345 = 32'h0;
-  assign _zz_346 = ((decode_INSTRUCTION & _zz_359) == 32'h0);
-  assign _zz_347 = (_zz_360 == _zz_361);
-  assign _zz_348 = {_zz_65,_zz_362};
-  assign _zz_349 = ((decode_INSTRUCTION & _zz_363) == 32'h0);
-  assign _zz_350 = {_zz_364,{_zz_365,_zz_366}};
-  assign _zz_351 = 3'b000;
-  assign _zz_352 = ({_zz_367,_zz_368} != 2'b00);
-  assign _zz_353 = (_zz_369 != _zz_370);
-  assign _zz_354 = (_zz_371 != _zz_372);
-  assign _zz_355 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_356 = 32'h00000004;
-  assign _zz_357 = (decode_INSTRUCTION & 32'h00000024);
-  assign _zz_358 = 32'h0;
-  assign _zz_359 = 32'h00000044;
-  assign _zz_360 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_361 = 32'h0;
-  assign _zz_362 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_363 = 32'h00000058;
-  assign _zz_364 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_365 = ((decode_INSTRUCTION & _zz_373) == 32'h00002010);
-  assign _zz_366 = ((decode_INSTRUCTION & _zz_374) == 32'h40000030);
-  assign _zz_367 = ((decode_INSTRUCTION & _zz_375) == 32'h00000004);
-  assign _zz_368 = _zz_64;
-  assign _zz_369 = {(_zz_376 == _zz_377),_zz_64};
-  assign _zz_370 = 2'b00;
-  assign _zz_371 = ((decode_INSTRUCTION & _zz_378) == 32'h00001004);
-  assign _zz_372 = 1'b0;
-  assign _zz_373 = 32'h00002014;
-  assign _zz_374 = 32'h40004034;
-  assign _zz_375 = 32'h00000014;
-  assign _zz_376 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_377 = 32'h00000004;
-  assign _zz_378 = 32'h00001054;
+  assign _zz_156 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign _zz_157 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_158 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_159 = ((_zz_149 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_160 = ((_zz_149 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_161 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign _zz_162 = ({CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_163 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_164 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_165 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_166 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign _zz_167 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_168 = (1'b1 || (! 1'b1));
+  assign _zz_169 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_170 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_171 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_172 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_173 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_174 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_175 = (iBus_cmd_valid || (_zz_141 != 3'b000));
+  assign _zz_176 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_177 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_178 = ((_zz_118 && 1'b1) && (! 1'b0));
+  assign _zz_179 = ((_zz_119 && 1'b1) && (! 1'b0));
+  assign _zz_180 = ((_zz_120 && 1'b1) && (! 1'b0));
+  assign _zz_181 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  assign _zz_182 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_183 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_184 = execute_INSTRUCTION[13];
+  assign _zz_185 = _zz_79[31 : 31];
+  assign _zz_186 = _zz_79[30 : 30];
+  assign _zz_187 = _zz_79[29 : 29];
+  assign _zz_188 = _zz_79[27 : 27];
+  assign _zz_189 = _zz_79[24 : 24];
+  assign _zz_190 = _zz_79[15 : 15];
+  assign _zz_191 = _zz_79[11 : 11];
+  assign _zz_192 = _zz_79[10 : 10];
+  assign _zz_193 = _zz_79[9 : 9];
+  assign _zz_194 = _zz_79[12 : 12];
+  assign _zz_195 = _zz_79[5 : 5];
+  assign _zz_196 = _zz_79[3 : 3];
+  assign _zz_197 = _zz_79[18 : 18];
+  assign _zz_198 = _zz_79[8 : 8];
+  assign _zz_199 = _zz_79[4 : 4];
+  assign _zz_200 = _zz_79[0 : 0];
+  assign _zz_201 = (_zz_58 - 3'b001);
+  assign _zz_202 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_203 = {29'd0, _zz_202};
+  assign _zz_204 = execute_SRC_LESS;
+  assign _zz_205 = 3'b100;
+  assign _zz_206 = execute_INSTRUCTION[19 : 15];
+  assign _zz_207 = execute_INSTRUCTION[31 : 20];
+  assign _zz_208 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_209 = ($signed(_zz_210) + $signed(_zz_213));
+  assign _zz_210 = ($signed(_zz_211) + $signed(_zz_212));
+  assign _zz_211 = execute_SRC1;
+  assign _zz_212 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_213 = (execute_SRC_USE_SUB_LESS ? _zz_214 : _zz_215);
+  assign _zz_214 = 32'h00000001;
+  assign _zz_215 = 32'h0;
+  assign _zz_216 = (_zz_217 >>> 1);
+  assign _zz_217 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_218 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_219 = execute_INSTRUCTION[31 : 20];
+  assign _zz_220 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_221 = (_zz_121 & (~ _zz_222));
+  assign _zz_222 = (_zz_121 - 2'b01);
+  assign _zz_223 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_224 = execute_INSTRUCTION[31 : 24];
+  assign _zz_225 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_226 = {5'd0, _zz_225};
+  assign _zz_227 = (_zz_229 + _zz_231);
+  assign _zz_228 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_229 = {{1{_zz_228[32]}}, _zz_228};
+  assign _zz_230 = _zz_232;
+  assign _zz_231 = {{1{_zz_230[32]}}, _zz_230};
+  assign _zz_232 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_233 = _zz_127;
+  assign _zz_234 = {32'd0, _zz_233};
+  assign _zz_235 = _zz_126;
+  assign _zz_236 = {31'd0, _zz_235};
+  assign _zz_237 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_238 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_239 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_240 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_241 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_242 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_243 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_244 = 1'b1;
+  assign _zz_245 = 1'b1;
+  assign _zz_246 = {_zz_61,_zz_60};
+  assign _zz_247 = 32'h0000106f;
+  assign _zz_248 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_249 = 32'h00001073;
+  assign _zz_250 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_251 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_252 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_253) == 32'h00000003),{(_zz_254 == _zz_255),{_zz_256,{_zz_257,_zz_258}}}}}};
+  assign _zz_253 = 32'h0000207f;
+  assign _zz_254 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_255 = 32'h00000003;
+  assign _zz_256 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_257 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_258 = {((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033),{((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & _zz_259) == 32'h00005013),{(_zz_260 == _zz_261),{_zz_262,{_zz_263,_zz_264}}}}}};
+  assign _zz_259 = 32'hbc00707f;
+  assign _zz_260 = (decode_INSTRUCTION & 32'hfc00705f);
+  assign _zz_261 = 32'h00001013;
+  assign _zz_262 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_263 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_264 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
+  assign _zz_265 = (decode_INSTRUCTION & 32'h02000074);
+  assign _zz_266 = 32'h02000030;
+  assign _zz_267 = _zz_84;
+  assign _zz_268 = 1'b0;
+  assign _zz_269 = (((decode_INSTRUCTION & 32'h10003050) == 32'h00000050) != 1'b0);
+  assign _zz_270 = (((decode_INSTRUCTION & _zz_272) == 32'h10000050) != 1'b0);
+  assign _zz_271 = {({_zz_273,_zz_274} != 2'b00),{({_zz_275,_zz_276} != 2'b00),{(_zz_277 != _zz_278),{_zz_279,{_zz_280,_zz_281}}}}};
+  assign _zz_272 = 32'h10403050;
+  assign _zz_273 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_274 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_275 = _zz_83;
+  assign _zz_276 = ((decode_INSTRUCTION & _zz_282) == 32'h00000004);
+  assign _zz_277 = ((decode_INSTRUCTION & _zz_283) == 32'h00000040);
+  assign _zz_278 = 1'b0;
+  assign _zz_279 = ({_zz_284,_zz_285} != 2'b00);
+  assign _zz_280 = (_zz_286 != 1'b0);
+  assign _zz_281 = {(_zz_287 != _zz_288),{_zz_289,{_zz_290,_zz_291}}};
+  assign _zz_282 = 32'h0000001c;
+  assign _zz_283 = 32'h00000058;
+  assign _zz_284 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz_285 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
+  assign _zz_286 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
+  assign _zz_287 = {(_zz_292 == _zz_293),{_zz_294,_zz_295}};
+  assign _zz_288 = 3'b000;
+  assign _zz_289 = ({_zz_296,{_zz_297,_zz_298}} != 3'b000);
+  assign _zz_290 = (_zz_299 != 1'b0);
+  assign _zz_291 = {(_zz_300 != _zz_301),{_zz_302,{_zz_303,_zz_304}}};
+  assign _zz_292 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz_293 = 32'h40001010;
+  assign _zz_294 = ((decode_INSTRUCTION & _zz_305) == 32'h00001010);
+  assign _zz_295 = ((decode_INSTRUCTION & _zz_306) == 32'h00001010);
+  assign _zz_296 = ((decode_INSTRUCTION & _zz_307) == 32'h00000024);
+  assign _zz_297 = (_zz_308 == _zz_309);
+  assign _zz_298 = (_zz_310 == _zz_311);
+  assign _zz_299 = ((decode_INSTRUCTION & _zz_312) == 32'h00001000);
+  assign _zz_300 = _zz_85;
+  assign _zz_301 = 1'b0;
+  assign _zz_302 = ({_zz_313,_zz_314} != 2'b00);
+  assign _zz_303 = (_zz_315 != _zz_316);
+  assign _zz_304 = {_zz_317,{_zz_318,_zz_319}};
+  assign _zz_305 = 32'h00007034;
+  assign _zz_306 = 32'h02007054;
+  assign _zz_307 = 32'h00000064;
+  assign _zz_308 = (decode_INSTRUCTION & 32'h00003034);
+  assign _zz_309 = 32'h00001010;
+  assign _zz_310 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz_311 = 32'h00001010;
+  assign _zz_312 = 32'h00001000;
+  assign _zz_313 = ((decode_INSTRUCTION & _zz_320) == 32'h00002000);
+  assign _zz_314 = ((decode_INSTRUCTION & _zz_321) == 32'h00001000);
+  assign _zz_315 = {(_zz_322 == _zz_323),(_zz_324 == _zz_325)};
+  assign _zz_316 = 2'b00;
+  assign _zz_317 = (_zz_81 != 1'b0);
+  assign _zz_318 = ({_zz_326,_zz_327} != 3'b000);
+  assign _zz_319 = {(_zz_328 != _zz_329),{_zz_330,{_zz_331,_zz_332}}};
+  assign _zz_320 = 32'h00002010;
+  assign _zz_321 = 32'h00005000;
+  assign _zz_322 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_323 = 32'h00006000;
+  assign _zz_324 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_325 = 32'h00004000;
+  assign _zz_326 = _zz_84;
+  assign _zz_327 = {(_zz_333 == _zz_334),(_zz_335 == _zz_336)};
+  assign _zz_328 = ((decode_INSTRUCTION & _zz_337) == 32'h00000020);
+  assign _zz_329 = 1'b0;
+  assign _zz_330 = ({_zz_338,_zz_339} != 2'b00);
+  assign _zz_331 = ({_zz_340,_zz_341} != 3'b000);
+  assign _zz_332 = {(_zz_342 != _zz_343),{_zz_344,{_zz_345,_zz_346}}};
+  assign _zz_333 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_334 = 32'h00000020;
+  assign _zz_335 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_336 = 32'h00000020;
+  assign _zz_337 = 32'h00000020;
+  assign _zz_338 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
+  assign _zz_339 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
+  assign _zz_340 = _zz_82;
+  assign _zz_341 = {(_zz_347 == _zz_348),(_zz_349 == _zz_350)};
+  assign _zz_342 = {_zz_83,{_zz_351,{_zz_352,_zz_353}}};
+  assign _zz_343 = 6'h0;
+  assign _zz_344 = ({_zz_82,_zz_354} != 2'b00);
+  assign _zz_345 = ({_zz_355,_zz_356} != 2'b00);
+  assign _zz_346 = {(_zz_357 != _zz_358),{_zz_359,{_zz_360,_zz_361}}};
+  assign _zz_347 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_348 = 32'h00000010;
+  assign _zz_349 = (decode_INSTRUCTION & 32'h02000060);
+  assign _zz_350 = 32'h00000020;
+  assign _zz_351 = ((decode_INSTRUCTION & _zz_362) == 32'h00001010);
+  assign _zz_352 = (_zz_363 == _zz_364);
+  assign _zz_353 = {_zz_365,{_zz_366,_zz_367}};
+  assign _zz_354 = ((decode_INSTRUCTION & _zz_368) == 32'h00000020);
+  assign _zz_355 = _zz_82;
+  assign _zz_356 = (_zz_369 == _zz_370);
+  assign _zz_357 = {_zz_371,{_zz_372,_zz_373}};
+  assign _zz_358 = 4'b0000;
+  assign _zz_359 = (_zz_374 != 1'b0);
+  assign _zz_360 = (_zz_375 != _zz_376);
+  assign _zz_361 = {_zz_377,{_zz_378,_zz_379}};
+  assign _zz_362 = 32'h00001010;
+  assign _zz_363 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_364 = 32'h00002010;
+  assign _zz_365 = ((decode_INSTRUCTION & _zz_380) == 32'h00000010);
+  assign _zz_366 = (_zz_381 == _zz_382);
+  assign _zz_367 = (_zz_383 == _zz_384);
+  assign _zz_368 = 32'h00000070;
+  assign _zz_369 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_370 = 32'h0;
+  assign _zz_371 = ((decode_INSTRUCTION & _zz_385) == 32'h0);
+  assign _zz_372 = (_zz_386 == _zz_387);
+  assign _zz_373 = {_zz_81,_zz_388};
+  assign _zz_374 = ((decode_INSTRUCTION & _zz_389) == 32'h0);
+  assign _zz_375 = {_zz_390,{_zz_391,_zz_392}};
+  assign _zz_376 = 3'b000;
+  assign _zz_377 = ({_zz_393,_zz_394} != 2'b00);
+  assign _zz_378 = (_zz_395 != _zz_396);
+  assign _zz_379 = (_zz_397 != _zz_398);
+  assign _zz_380 = 32'h00000050;
+  assign _zz_381 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_382 = 32'h00000004;
+  assign _zz_383 = (decode_INSTRUCTION & 32'h00000024);
+  assign _zz_384 = 32'h0;
+  assign _zz_385 = 32'h00000044;
+  assign _zz_386 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_387 = 32'h0;
+  assign _zz_388 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_389 = 32'h00000058;
+  assign _zz_390 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_391 = ((decode_INSTRUCTION & _zz_399) == 32'h00002010);
+  assign _zz_392 = ((decode_INSTRUCTION & _zz_400) == 32'h40000030);
+  assign _zz_393 = ((decode_INSTRUCTION & _zz_401) == 32'h00000004);
+  assign _zz_394 = _zz_80;
+  assign _zz_395 = {(_zz_402 == _zz_403),_zz_80};
+  assign _zz_396 = 2'b00;
+  assign _zz_397 = ((decode_INSTRUCTION & _zz_404) == 32'h00001004);
+  assign _zz_398 = 1'b0;
+  assign _zz_399 = 32'h00002014;
+  assign _zz_400 = 32'h40004034;
+  assign _zz_401 = 32'h00000014;
+  assign _zz_402 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_403 = 32'h00000004;
+  assign _zz_404 = 32'h00001054;
   always @ (posedge clk) begin
-    if(_zz_226) begin
-      _zz_141 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_244) begin
+      _zz_153 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_227) begin
-      _zz_142 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_245) begin
+      _zz_154 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_32) begin
+    if(_zz_46) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_132                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_133                                                     ), //i
+    .io_flush                                 (_zz_144                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_145                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_134                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_135                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_136                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_146                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_147                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_148                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1204,8 +1374,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_137                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_138                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_149                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_150                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1213,8 +1383,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_139                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_140                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_151                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_152                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1227,32 +1397,15 @@ module VexRiscv (
     .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_228)
+    case(_zz_246)
       2'b00 : begin
-        _zz_143 = DBusSimplePlugin_redoBranch_payload;
+        _zz_155 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_143 = CsrPlugin_jumpInterface_payload;
+        _zz_155 = DBusSimplePlugin_redoBranch_payload;
       end
       default : begin
-        _zz_143 = BranchPlugin_jumpInterface_payload;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_110)
-      2'b00 : begin
-        _zz_144 = DBusSimplePlugin_memoryExceptionPort_payload_code;
-        _zz_145 = DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
-      end
-      2'b01 : begin
-        _zz_144 = CsrPlugin_selfException_payload_code;
-        _zz_145 = CsrPlugin_selfException_payload_badAddr;
-      end
-      default : begin
-        _zz_144 = CfuPlugin_joinException_payload_code;
-        _zz_145 = CfuPlugin_joinException_payload_badAddr;
+        _zz_155 = BranchPlugin_jumpInterface_payload;
       end
     endcase
   end
@@ -1287,14 +1440,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_4)
       `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
       `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
@@ -1319,6 +1464,46 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8_string = "ECALL";
+      default : _zz_8_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9_string = "ECALL";
+      default : _zz_9_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10_string = "ECALL";
+      default : _zz_10_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
       `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
@@ -1328,30 +1513,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_7_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_7_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_7_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_7_string = "JALR";
-      default : _zz_7_string = "????";
+    case(_zz_11)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_11_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_11_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11_string = "JALR";
+      default : _zz_11_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_12)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_12_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_12_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12_string = "JALR";
+      default : _zz_12_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_13)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_13_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_13_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_13_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_13_string = "JALR";
+      default : _zz_13_string = "????";
     endcase
   end
   always @(*) begin
@@ -1364,30 +1549,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_15)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
+      default : _zz_15_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_16)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
+      default : _zz_16_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1399,27 +1584,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13_string = "AND_1";
-      default : _zz_13_string = "?????";
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
+    case(_zz_18)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
+      default : _zz_18_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_19)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
+      default : _zz_19_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1431,93 +1616,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16_string = "BITWISE ";
-      default : _zz_16_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_17_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_17_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_17_string = "BITWISE ";
-      default : _zz_17_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_18_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_18_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_18_string = "BITWISE ";
-      default : _zz_18_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_defaultEncoding_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
-      default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19)
-      `Input2Kind_defaultEncoding_RS : _zz_19_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_19_string = "IMM_I";
-      default : _zz_19_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : execute_ENV_CTRL_string = "ECALL";
-      default : execute_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_20)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20_string = "ECALL";
-      default : _zz_20_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : execute_BRANCH_CTRL_string = "JALR";
-      default : execute_BRANCH_CTRL_string = "????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_21)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_21_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_21_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_21_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_21_string = "JALR";
-      default : _zz_21_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_22)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_22_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_22_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_22_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_22_string = "SRA_1    ";
-      default : _zz_22_string = "?????????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1527,6 +1646,24 @@ module VexRiscv (
       `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
+      default : _zz_23_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_24_string = "PC ";
+      default : _zz_24_string = "???";
     endcase
   end
   always @(*) begin
@@ -1548,6 +1685,15 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_27)
       `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
       `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
@@ -1557,42 +1703,50 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
-      default : execute_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_28)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_28_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_28_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_28_string = "BITWISE ";
-      default : _zz_28_string = "????????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
+      default : _zz_28_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_29_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_29_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_29_string = "AND_1";
-      default : _zz_29_string = "?????";
+    case(_zz_32)
+      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
+      default : _zz_32_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_ENV_CTRL_string = "ECALL";
+      default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_33)
-      `Input2Kind_defaultEncoding_RS : _zz_33_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_33_string = "IMM_I";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
       default : _zz_33_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_ENV_CTRL_string = "ECALL";
+      default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1604,122 +1758,275 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      default : writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_35)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_35_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_35_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_35_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_35_string = "JALR";
-      default : _zz_35_string = "????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
+      default : _zz_35_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : execute_BRANCH_CTRL_string = "JALR";
+      default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_36)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_36_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_36_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_36_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_36_string = "SRA_1    ";
-      default : _zz_36_string = "?????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
+      default : _zz_36_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_37_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_37_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_37_string = "AND_1";
-      default : _zz_37_string = "?????";
+    case(execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_38_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_38_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_38_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_38_string = "SRA_1    ";
+      default : _zz_38_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_39_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_39_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_39_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_39_string = "PC ";
-      default : _zz_39_string = "???";
+    case(execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : execute_SRC2_CTRL_string = "PC ";
+      default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_40)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_40_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_40_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_40_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_40_string = "URS1        ";
-      default : _zz_40_string = "????????????";
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_40_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_40_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_40_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_40_string = "PC ";
+      default : _zz_40_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_72)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_72_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_72_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_72_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_72_string = "URS1        ";
-      default : _zz_72_string = "????????????";
+    case(execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_73)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_73_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_73_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_73_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_73_string = "PC ";
-      default : _zz_73_string = "???";
+    case(_zz_41)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_41_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_41_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_41_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_41_string = "URS1        ";
+      default : _zz_41_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_74)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_74_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_74_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_74_string = "BITWISE ";
-      default : _zz_74_string = "????????";
+    case(execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_75)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_75_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_75_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_75_string = "AND_1";
-      default : _zz_75_string = "?????";
+    case(_zz_42)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_42_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_42_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_42_string = "BITWISE ";
+      default : _zz_42_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_76)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_76_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_76_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_76_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_76_string = "SRA_1    ";
-      default : _zz_76_string = "?????????";
+    case(execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_77)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_77_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_77_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_77_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_77_string = "JALR";
-      default : _zz_77_string = "????";
+    case(_zz_43)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_78)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_78_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_78_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_78_string = "ECALL";
-      default : _zz_78_string = "?????";
+    case(_zz_47)
+      `Input2Kind_defaultEncoding_RS : _zz_47_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_47_string = "IMM_I";
+      default : _zz_47_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_79)
-      `Input2Kind_defaultEncoding_RS : _zz_79_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_79_string = "IMM_I";
-      default : _zz_79_string = "?????";
+    case(_zz_48)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_48_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_48_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_48_string = "ECALL";
+      default : _zz_48_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_49)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_49_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_49_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_49_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_49_string = "JALR";
+      default : _zz_49_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_50)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_50_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_50_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_50_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_50_string = "SRA_1    ";
+      default : _zz_50_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_51)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_51_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_51_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_51_string = "AND_1";
+      default : _zz_51_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_52)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_52_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_52_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_52_string = "BITWISE ";
+      default : _zz_52_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_53)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_53_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_53_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_53_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_53_string = "PC ";
+      default : _zz_53_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_54)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_54_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_54_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_54_string = "URS1        ";
+      default : _zz_54_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_87)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_87_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_87_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_87_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_87_string = "URS1        ";
+      default : _zz_87_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_88)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_88_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_88_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_88_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_88_string = "PC ";
+      default : _zz_88_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_89)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_89_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_89_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_89_string = "BITWISE ";
+      default : _zz_89_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_90)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_90_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_90_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_90_string = "AND_1";
+      default : _zz_90_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_91)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_91_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_91_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_91_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_91_string = "SRA_1    ";
+      default : _zz_91_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_92)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_92_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_92_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_92_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_92_string = "JALR";
+      default : _zz_92_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_93)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_93_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_93_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_93_string = "ECALL";
+      default : _zz_93_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_94)
+      `Input2Kind_defaultEncoding_RS : _zz_94_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_94_string = "IMM_I";
+      default : _zz_94_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1765,6 +2072,22 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : execute_to_memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
       `Input2Kind_defaultEncoding_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
       `Input2Kind_defaultEncoding_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
@@ -1773,108 +2096,168 @@ module VexRiscv (
   end
   `endif
 
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
+  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+  assign execute_REGFILE_WRITE_DATA = _zz_96;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_SRC2 = _zz_87;
-  assign decode_SRC1 = _zz_82;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign decode_IS_RS2_SIGNED = _zz_170[0];
-  assign decode_IS_RS1_SIGNED = _zz_171[0];
-  assign decode_IS_MUL = _zz_172[0];
+  assign decode_IS_RS2_SIGNED = _zz_185[0];
+  assign decode_IS_RS1_SIGNED = _zz_186[0];
+  assign decode_IS_MUL = _zz_187[0];
   assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
   assign _zz_2 = _zz_3;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_173[0];
-  assign decode_ENV_CTRL = _zz_4;
-  assign _zz_5 = _zz_6;
-  assign decode_IS_CSR = _zz_174[0];
-  assign decode_BRANCH_CTRL = _zz_7;
-  assign _zz_8 = _zz_9;
-  assign decode_SHIFT_CTRL = _zz_10;
-  assign _zz_11 = _zz_12;
-  assign decode_ALU_BITWISE_CTRL = _zz_13;
-  assign _zz_14 = _zz_15;
-  assign decode_SRC_LESS_UNSIGNED = _zz_175[0];
-  assign decode_ALU_CTRL = _zz_16;
-  assign _zz_17 = _zz_18;
-  assign decode_MEMORY_STORE = _zz_176[0];
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_188[0];
+  assign _zz_4 = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_ENV_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_IS_CSR = _zz_189[0];
+  assign decode_BRANCH_CTRL = _zz_11;
+  assign _zz_12 = _zz_13;
+  assign decode_SHIFT_CTRL = _zz_14;
+  assign _zz_15 = _zz_16;
+  assign decode_ALU_BITWISE_CTRL = _zz_17;
+  assign _zz_18 = _zz_19;
+  assign decode_SRC_LESS_UNSIGNED = _zz_190[0];
+  assign decode_ALU_CTRL = _zz_20;
+  assign _zz_21 = _zz_22;
+  assign decode_MEMORY_STORE = _zz_191[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_192[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_193[0];
+  assign decode_SRC2_CTRL = _zz_23;
+  assign _zz_24 = _zz_25;
+  assign decode_SRC1_CTRL = _zz_26;
+  assign _zz_27 = _zz_28;
+  assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
+  assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
-  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
-  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_19;
+  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  always @ (*) begin
+    _zz_29 = memory_CfuPlugin_CFU_IN_FLIGHT;
+    if(memory_arbitration_isStuck)begin
+      _zz_29 = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    _zz_30 = execute_CfuPlugin_CFU_IN_FLIGHT;
+    if(execute_arbitration_isStuck)begin
+      _zz_30 = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    _zz_31 = memory_REGFILE_WRITE_DATA;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      _zz_31 = memory_CfuPlugin_rsp_payload_outputs_0;
+    end
+    if(_zz_156)begin
+      _zz_31 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    end
+  end
+
+  assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign execute_ENV_CTRL = _zz_20;
+  assign memory_ENV_CTRL = _zz_33;
+  assign execute_ENV_CTRL = _zz_34;
+  assign writeBack_ENV_CTRL = _zz_35;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_95;
+  assign execute_BRANCH_DO = _zz_110;
+  assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_21;
-  assign decode_RS2_USE = _zz_177[0];
-  assign decode_RS1_USE = _zz_178[0];
+  assign execute_BRANCH_CTRL = _zz_36;
+  assign decode_RS2_USE = _zz_194[0];
+  assign decode_RS1_USE = _zz_195[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
-  assign execute_SHIFT_CTRL = _zz_22;
+  assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
+  assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
+  assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
+  always @ (*) begin
+    _zz_37 = execute_REGFILE_WRITE_DATA;
+    if(_zz_157)begin
+      _zz_37 = _zz_103;
+    end
+    if(_zz_158)begin
+      _zz_37 = execute_CsrPlugin_readData;
+    end
+  end
+
+  assign execute_SHIFT_CTRL = _zz_38;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_23 = decode_PC;
-  assign _zz_24 = decode_RS2;
-  assign decode_SRC2_CTRL = _zz_25;
-  assign _zz_26 = decode_RS1;
-  assign decode_SRC1_CTRL = _zz_27;
-  assign decode_SRC_USE_SUB_LESS = _zz_179[0];
-  assign decode_SRC_ADD_ZERO = _zz_180[0];
+  assign _zz_39 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_40;
+  assign execute_SRC1_CTRL = _zz_41;
+  assign decode_SRC_USE_SUB_LESS = _zz_196[0];
+  assign decode_SRC_ADD_ZERO = _zz_197[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_28;
-  assign execute_SRC2 = decode_to_execute_SRC2;
-  assign execute_SRC1 = decode_to_execute_SRC1;
-  assign execute_ALU_BITWISE_CTRL = _zz_29;
-  assign _zz_30 = execute_INSTRUCTION;
-  assign _zz_31 = execute_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_42;
+  assign execute_SRC2 = _zz_102;
+  assign execute_SRC1 = _zz_97;
+  assign execute_ALU_BITWISE_CTRL = _zz_43;
+  assign _zz_44 = writeBack_INSTRUCTION;
+  assign _zz_45 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_32 = 1'b0;
+    _zz_46 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_32 = 1'b1;
+      _zz_46 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_181[0];
+    decode_REGFILE_WRITE_VALID = _zz_198[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_229) == 32'h00000003),{(_zz_230 == _zz_231),{_zz_232,{_zz_233,_zz_234}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_247) == 32'h00000003),{(_zz_248 == _zz_249),{_zz_250,{_zz_251,_zz_252}}}}}}} != 22'h0);
+  assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_41 = execute_REGFILE_WRITE_DATA;
-    if((execute_arbitration_isValid && execute_MEMORY_ENABLE))begin
-      _zz_41 = execute_DBusSimplePlugin_rspFormated;
-    end
-    if(_zz_146)begin
-      _zz_41 = _zz_88;
-    end
-    if(_zz_147)begin
-      _zz_41 = execute_CsrPlugin_readData;
-    end
-    if(execute_CfuPlugin_CFU_IN_FLIGHT)begin
-      _zz_41 = execute_CfuPlugin_rsp_payload_outputs_0;
-    end
-    if(_zz_148)begin
-      _zz_41 = ((execute_INSTRUCTION[13 : 12] == 2'b00) ? execute_MulDivIterativePlugin_accumulator[31 : 0] : execute_MulDivIterativePlugin_accumulator[63 : 32]);
+    _zz_55 = writeBack_REGFILE_WRITE_DATA;
+    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
+      _zz_55 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
-  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
-  assign execute_MEMORY_READ_DATA = dBus_rsp_data;
-  assign execute_REGFILE_WRITE_DATA = _zz_81;
+  assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
+  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
+  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
+  assign memory_MMU_RSP2_physicalAddress = execute_to_memory_MMU_RSP2_physicalAddress;
+  assign memory_MMU_RSP2_isIoAccess = execute_to_memory_MMU_RSP2_isIoAccess;
+  assign memory_MMU_RSP2_isPaging = execute_to_memory_MMU_RSP2_isPaging;
+  assign memory_MMU_RSP2_allowRead = execute_to_memory_MMU_RSP2_allowRead;
+  assign memory_MMU_RSP2_allowWrite = execute_to_memory_MMU_RSP2_allowWrite;
+  assign memory_MMU_RSP2_allowExecute = execute_to_memory_MMU_RSP2_allowExecute;
+  assign memory_MMU_RSP2_exception = execute_to_memory_MMU_RSP2_exception;
+  assign memory_MMU_RSP2_refilling = execute_to_memory_MMU_RSP2_refilling;
+  assign memory_MMU_RSP2_bypassTranslation = execute_to_memory_MMU_RSP2_bypassTranslation;
+  assign memory_PC = execute_to_memory_PC;
+  assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
+  assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MMU_FAULT = ((execute_MMU_RSP2_exception || ((! execute_MMU_RSP2_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP2_allowRead) && (! execute_MEMORY_STORE)));
   assign execute_MMU_RSP2_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
   assign execute_MMU_RSP2_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
@@ -1887,29 +2270,44 @@ module VexRiscv (
   assign execute_MMU_RSP2_bypassTranslation = DBusSimplePlugin_mmuBus_rsp_bypassTranslation;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
+  assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = 1'b0;
-  assign decode_MEMORY_ENABLE = _zz_182[0];
-  assign decode_FLUSH_ALL = _zz_183[0];
+  assign decode_MEMORY_ENABLE = _zz_199[0];
+  assign decode_FLUSH_ALL = _zz_200[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_149)begin
+    if(_zz_159)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_150)begin
+    if(_zz_160)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
+  always @ (*) begin
+    _zz_56 = execute_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid)begin
+      _zz_56 = BranchPlugin_jumpInterface_payload;
+    end
+  end
+
+  always @ (*) begin
+    _zz_57 = memory_FORMAL_PC_NEXT;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      _zz_57 = DBusSimplePlugin_redoBranch_payload;
+    end
+  end
+
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
-  assign execute_PC = decode_to_execute_PC;
-  assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
+  assign writeBack_PC = memory_to_writeBack_PC;
+  assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @ (*) begin
     decode_arbitration_haltItself = 1'b0;
     if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
@@ -1919,13 +2317,13 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_89 || _zz_90)))begin
+    if((decode_arbitration_isValid && (_zz_104 || _zz_105)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)) != 1'b0))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -1950,18 +2348,15 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_56)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_72)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_MEMORY_STORE)) && ((! dBus_rsp_ready) || (! _zz_56))))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_146)begin
+    if(_zz_157)begin
       if((! execute_LightShifterPlugin_done))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_147)begin
+    if(_zz_158)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -1969,25 +2364,12 @@ module VexRiscv (
     if((CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(execute_CfuPlugin_CFU_IN_FLIGHT)begin
-      if((! execute_CfuPlugin_rsp_valid))begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(_zz_148)begin
-      if(((! execute_MulDivIterativePlugin_frontendOk) || (! execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-      if(_zz_151)begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-    end
   end
 
   assign execute_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(_zz_152)begin
+    if(CsrPlugin_selfException_valid)begin
       execute_arbitration_removeIt = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -1995,45 +2377,98 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    execute_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      execute_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign execute_arbitration_flushIt = 1'b0;
   always @ (*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
     if(BranchPlugin_jumpInterface_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_152)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(_zz_153)begin
-      execute_arbitration_flushNext = 1'b1;
-    end
-    if(_zz_154)begin
+    if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  assign lastStageInstruction = execute_INSTRUCTION;
-  assign lastStagePc = execute_PC;
-  assign lastStageIsValid = execute_arbitration_isValid;
-  assign lastStageIsFiring = execute_arbitration_isFiring;
+  always @ (*) begin
+    memory_arbitration_haltItself = 1'b0;
+    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+      memory_arbitration_haltItself = 1'b1;
+    end
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if((! memory_CfuPlugin_rsp_valid))begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(_zz_156)begin
+      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+      if(_zz_161)begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+  end
+
+  assign memory_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    memory_arbitration_removeIt = 1'b0;
+    if(_zz_162)begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+    if(memory_arbitration_isFlushed)begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    memory_arbitration_flushIt = 1'b0;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      memory_arbitration_flushIt = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    memory_arbitration_flushNext = 1'b0;
+    if(DBusSimplePlugin_redoBranch_valid)begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+    if(_zz_162)begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_haltItself = 1'b0;
+  assign writeBack_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    writeBack_arbitration_removeIt = 1'b0;
+    if(writeBack_arbitration_isFlushed)begin
+      writeBack_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_flushIt = 1'b0;
+  always @ (*) begin
+    writeBack_arbitration_flushNext = 1'b0;
+    if(_zz_163)begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(_zz_164)begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign lastStageInstruction = writeBack_INSTRUCTION;
+  assign lastStagePc = writeBack_PC;
+  assign lastStageIsValid = writeBack_arbitration_isValid;
+  assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode} != 2'b00))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_153)begin
+    if(_zz_163)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_154)begin
+    if(_zz_164)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2049,21 +2484,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_153)begin
+    if(_zz_163)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_154)begin
+    if(_zz_164)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_153)begin
+    if(_zz_163)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_154)begin
-      case(_zz_155)
+    if(_zz_164)begin
+      case(_zz_165)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2076,13 +2511,13 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({execute_arbitration_flushNext,decode_arbitration_flushNext} != 2'b00);
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != 3'b000);
-  assign _zz_42 = {BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}};
-  assign _zz_43 = (_zz_42 & (~ _zz_184));
-  assign _zz_44 = _zz_43[1];
-  assign _zz_45 = _zz_43[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_143;
+  assign _zz_58 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_59 = (_zz_58 & (~ _zz_201));
+  assign _zz_60 = _zz_59[1];
+  assign _zz_61 = _zz_59[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_155;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -2102,7 +2537,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_186);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_203);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -2142,9 +2577,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_46 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_46);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_46);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -2153,9 +2588,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_47 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_47);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_47);
+  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -2164,22 +2599,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_48 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_48);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_48);
+  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_49;
-  assign _zz_49 = ((1'b0 && (! _zz_50)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_50 = _zz_51;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_50;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65;
+  assign _zz_65 = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_66 = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_52)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_52 = _zz_53;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_52;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_54;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_68 = _zz_69;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -2189,6 +2624,8 @@ module VexRiscv (
 
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
@@ -2199,33 +2636,33 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_133 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_134 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_135 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_134;
+  assign _zz_145 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_146 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_147 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_146;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_137 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_138 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_139 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_149 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_150 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_151 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_150)begin
+    if(_zz_160)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_149)begin
+    if(_zz_159)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_140 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_149)begin
-      _zz_140 = 1'b1;
+    _zz_152 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_159)begin
+      _zz_152 = 1'b1;
     end
   end
 
@@ -2233,7 +2670,8 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_132 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_144 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_72 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
@@ -2244,39 +2682,39 @@ module VexRiscv (
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_56));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_72));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_57 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_73 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_57 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_73 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_57 = execute_RS2[31 : 0];
+        _zz_73 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_57;
+  assign dBus_cmd_payload_data = _zz_73;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_58 = 4'b0001;
+        _zz_74 = 4'b0001;
       end
       2'b01 : begin
-        _zz_58 = 4'b0011;
+        _zz_74 = 4'b0011;
       end
       default : begin
-        _zz_58 = 4'b1111;
+        _zz_74 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_58 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_74 <<< dBus_cmd_payload_address[1 : 0]);
   assign DBusSimplePlugin_mmuBus_cmd_0_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign DBusSimplePlugin_mmuBus_cmd_0_isStuck = execute_arbitration_isStuck;
   assign DBusSimplePlugin_mmuBus_cmd_0_virtualAddress = execute_SRC_ADD;
@@ -2285,116 +2723,116 @@ module VexRiscv (
   assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(execute_MMU_RSP2_refilling)begin
+    if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end else begin
-      if(execute_MMU_FAULT)begin
+      if(memory_MMU_FAULT)begin
         DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
       end
     end
-    if(_zz_156)begin
+    if(_zz_166)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(! execute_MMU_RSP2_refilling) begin
-      if(execute_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (execute_MEMORY_STORE ? 4'b1111 : 4'b1101);
+    if(! memory_MMU_RSP2_refilling) begin
+      if(memory_MMU_FAULT)begin
+        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 4'b1111 : 4'b1101);
       end
     end
   end
 
-  assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = execute_REGFILE_WRITE_DATA;
+  assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(execute_MMU_RSP2_refilling)begin
+    if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_redoBranch_valid = 1'b1;
     end
-    if(_zz_156)begin
+    if(_zz_166)begin
       DBusSimplePlugin_redoBranch_valid = 1'b0;
     end
   end
 
-  assign DBusSimplePlugin_redoBranch_payload = execute_PC;
+  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
-    execute_DBusSimplePlugin_rspShifted = execute_MEMORY_READ_DATA;
-    case(execute_MEMORY_ADDRESS_LOW)
+    writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
+    case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        execute_DBusSimplePlugin_rspShifted[7 : 0] = execute_MEMORY_READ_DATA[15 : 8];
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[15 : 8];
       end
       2'b10 : begin
-        execute_DBusSimplePlugin_rspShifted[15 : 0] = execute_MEMORY_READ_DATA[31 : 16];
+        writeBack_DBusSimplePlugin_rspShifted[15 : 0] = writeBack_MEMORY_READ_DATA[31 : 16];
       end
       2'b11 : begin
-        execute_DBusSimplePlugin_rspShifted[7 : 0] = execute_MEMORY_READ_DATA[31 : 24];
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_59 = (execute_DBusSimplePlugin_rspShifted[7] && (! execute_INSTRUCTION[14]));
+  assign _zz_75 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_60[31] = _zz_59;
-    _zz_60[30] = _zz_59;
-    _zz_60[29] = _zz_59;
-    _zz_60[28] = _zz_59;
-    _zz_60[27] = _zz_59;
-    _zz_60[26] = _zz_59;
-    _zz_60[25] = _zz_59;
-    _zz_60[24] = _zz_59;
-    _zz_60[23] = _zz_59;
-    _zz_60[22] = _zz_59;
-    _zz_60[21] = _zz_59;
-    _zz_60[20] = _zz_59;
-    _zz_60[19] = _zz_59;
-    _zz_60[18] = _zz_59;
-    _zz_60[17] = _zz_59;
-    _zz_60[16] = _zz_59;
-    _zz_60[15] = _zz_59;
-    _zz_60[14] = _zz_59;
-    _zz_60[13] = _zz_59;
-    _zz_60[12] = _zz_59;
-    _zz_60[11] = _zz_59;
-    _zz_60[10] = _zz_59;
-    _zz_60[9] = _zz_59;
-    _zz_60[8] = _zz_59;
-    _zz_60[7 : 0] = execute_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_76[31] = _zz_75;
+    _zz_76[30] = _zz_75;
+    _zz_76[29] = _zz_75;
+    _zz_76[28] = _zz_75;
+    _zz_76[27] = _zz_75;
+    _zz_76[26] = _zz_75;
+    _zz_76[25] = _zz_75;
+    _zz_76[24] = _zz_75;
+    _zz_76[23] = _zz_75;
+    _zz_76[22] = _zz_75;
+    _zz_76[21] = _zz_75;
+    _zz_76[20] = _zz_75;
+    _zz_76[19] = _zz_75;
+    _zz_76[18] = _zz_75;
+    _zz_76[17] = _zz_75;
+    _zz_76[16] = _zz_75;
+    _zz_76[15] = _zz_75;
+    _zz_76[14] = _zz_75;
+    _zz_76[13] = _zz_75;
+    _zz_76[12] = _zz_75;
+    _zz_76[11] = _zz_75;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_61 = (execute_DBusSimplePlugin_rspShifted[15] && (! execute_INSTRUCTION[14]));
+  assign _zz_77 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_62[31] = _zz_61;
-    _zz_62[30] = _zz_61;
-    _zz_62[29] = _zz_61;
-    _zz_62[28] = _zz_61;
-    _zz_62[27] = _zz_61;
-    _zz_62[26] = _zz_61;
-    _zz_62[25] = _zz_61;
-    _zz_62[24] = _zz_61;
-    _zz_62[23] = _zz_61;
-    _zz_62[22] = _zz_61;
-    _zz_62[21] = _zz_61;
-    _zz_62[20] = _zz_61;
-    _zz_62[19] = _zz_61;
-    _zz_62[18] = _zz_61;
-    _zz_62[17] = _zz_61;
-    _zz_62[16] = _zz_61;
-    _zz_62[15 : 0] = execute_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_78[31] = _zz_77;
+    _zz_78[30] = _zz_77;
+    _zz_78[29] = _zz_77;
+    _zz_78[28] = _zz_77;
+    _zz_78[27] = _zz_77;
+    _zz_78[26] = _zz_77;
+    _zz_78[25] = _zz_77;
+    _zz_78[24] = _zz_77;
+    _zz_78[23] = _zz_77;
+    _zz_78[22] = _zz_77;
+    _zz_78[21] = _zz_77;
+    _zz_78[20] = _zz_77;
+    _zz_78[19] = _zz_77;
+    _zz_78[18] = _zz_77;
+    _zz_78[17] = _zz_77;
+    _zz_78[16] = _zz_77;
+    _zz_78[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_168)
+    case(_zz_183)
       2'b00 : begin
-        execute_DBusSimplePlugin_rspFormated = _zz_60;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_76;
       end
       2'b01 : begin
-        execute_DBusSimplePlugin_rspFormated = _zz_62;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_78;
       end
       default : begin
-        execute_DBusSimplePlugin_rspFormated = execute_DBusSimplePlugin_rspShifted;
+        writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
       end
     endcase
   end
@@ -2417,55 +2855,54 @@ module VexRiscv (
   assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_64 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_65 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_66 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_67 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_68 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_69 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_70 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_71 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
-  assign _zz_63 = {(_zz_71 != 1'b0),{({_zz_71,_zz_70} != 2'b00),{((_zz_247 == _zz_248) != 1'b0),{1'b0,{(_zz_249 != _zz_250),{_zz_251,{_zz_252,_zz_253}}}}}}};
-  assign _zz_72 = _zz_63[2 : 1];
-  assign _zz_40 = _zz_72;
-  assign _zz_73 = _zz_63[7 : 6];
-  assign _zz_39 = _zz_73;
-  assign _zz_74 = _zz_63[14 : 13];
-  assign _zz_38 = _zz_74;
-  assign _zz_75 = _zz_63[17 : 16];
-  assign _zz_37 = _zz_75;
-  assign _zz_76 = _zz_63[20 : 19];
-  assign _zz_36 = _zz_76;
-  assign _zz_77 = _zz_63[23 : 22];
-  assign _zz_35 = _zz_77;
-  assign _zz_78 = _zz_63[26 : 25];
-  assign _zz_34 = _zz_78;
-  assign _zz_79 = _zz_63[28 : 28];
-  assign _zz_33 = _zz_79;
+  assign _zz_80 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_81 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_82 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_83 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_84 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_85 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_86 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
+  assign _zz_79 = {(_zz_86 != 1'b0),{({_zz_86,_zz_85} != 2'b00),{((_zz_265 == _zz_266) != 1'b0),{1'b0,{(_zz_267 != _zz_268),{_zz_269,{_zz_270,_zz_271}}}}}}};
+  assign _zz_87 = _zz_79[2 : 1];
+  assign _zz_54 = _zz_87;
+  assign _zz_88 = _zz_79[7 : 6];
+  assign _zz_53 = _zz_88;
+  assign _zz_89 = _zz_79[14 : 13];
+  assign _zz_52 = _zz_89;
+  assign _zz_90 = _zz_79[17 : 16];
+  assign _zz_51 = _zz_90;
+  assign _zz_91 = _zz_79[20 : 19];
+  assign _zz_50 = _zz_91;
+  assign _zz_92 = _zz_79[23 : 22];
+  assign _zz_49 = _zz_92;
+  assign _zz_93 = _zz_79[26 : 25];
+  assign _zz_48 = _zz_93;
+  assign _zz_94 = _zz_79[28 : 28];
+  assign _zz_47 = _zz_94;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_141;
-  assign decode_RegFilePlugin_rs2Data = _zz_142;
+  assign decode_RegFilePlugin_rs1Data = _zz_153;
+  assign decode_RegFilePlugin_rs2Data = _zz_154;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_31 && execute_arbitration_isFiring);
-    if(_zz_80)begin
+    lastStageRegFileWrite_valid = (_zz_45 && writeBack_arbitration_isFiring);
+    if(_zz_95)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_30[11 : 7];
-    if(_zz_80)begin
+    lastStageRegFileWrite_payload_address = _zz_44[11 : 7];
+    if(_zz_95)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_41;
-    if(_zz_80)begin
+    lastStageRegFileWrite_payload_data = _zz_55;
+    if(_zz_95)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -2487,208 +2924,35 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_81 = execute_IntAluPlugin_bitwise;
+        _zz_96 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_81 = {31'd0, _zz_187};
+        _zz_96 = {31'd0, _zz_204};
       end
       default : begin
-        _zz_81 = execute_SRC_ADD_SUB;
+        _zz_96 = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
   always @ (*) begin
-    case(decode_SRC1_CTRL)
+    case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_82 = _zz_26;
+        _zz_97 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_82 = {29'd0, _zz_188};
+        _zz_97 = {29'd0, _zz_205};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_82 = {decode_INSTRUCTION[31 : 12],12'h0};
+        _zz_97 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_82 = {27'd0, _zz_189};
+        _zz_97 = {27'd0, _zz_206};
       end
     endcase
   end
 
-  assign _zz_83 = _zz_190[11];
-  always @ (*) begin
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7] = _zz_83;
-    _zz_84[6] = _zz_83;
-    _zz_84[5] = _zz_83;
-    _zz_84[4] = _zz_83;
-    _zz_84[3] = _zz_83;
-    _zz_84[2] = _zz_83;
-    _zz_84[1] = _zz_83;
-    _zz_84[0] = _zz_83;
-  end
-
-  assign _zz_85 = _zz_191[11];
-  always @ (*) begin
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15] = _zz_85;
-    _zz_86[14] = _zz_85;
-    _zz_86[13] = _zz_85;
-    _zz_86[12] = _zz_85;
-    _zz_86[11] = _zz_85;
-    _zz_86[10] = _zz_85;
-    _zz_86[9] = _zz_85;
-    _zz_86[8] = _zz_85;
-    _zz_86[7] = _zz_85;
-    _zz_86[6] = _zz_85;
-    _zz_86[5] = _zz_85;
-    _zz_86[4] = _zz_85;
-    _zz_86[3] = _zz_85;
-    _zz_86[2] = _zz_85;
-    _zz_86[1] = _zz_85;
-    _zz_86[0] = _zz_85;
-  end
-
-  always @ (*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_87 = _zz_24;
-      end
-      `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_87 = {_zz_84,decode_INSTRUCTION[31 : 20]};
-      end
-      `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_87 = {_zz_86,{decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]}};
-      end
-      default : begin
-        _zz_87 = _zz_23;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_192;
-    if(execute_SRC2_FORCE_ZERO)begin
-      execute_SrcPlugin_addSub = execute_SRC1;
-    end
-  end
-
-  assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
-  assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
-  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_shiftReg : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  always @ (*) begin
-    case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_88 = (execute_LightShifterPlugin_shiftInput <<< 1);
-      end
-      default : begin
-        _zz_88 = _zz_199;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_89 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_89 = 1'b1;
-      end
-    end
-    if(_zz_157)begin
-      if(_zz_158)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS1_USE))begin
-      _zz_89 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_90 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_90 = 1'b1;
-      end
-    end
-    if(_zz_157)begin
-      if(_zz_158)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_90 = 1'b0;
-    end
-  end
-
-  assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_93 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_93 == 3'b000)) begin
-        _zz_94 = execute_BranchPlugin_eq;
-    end else if((_zz_93 == 3'b001)) begin
-        _zz_94 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_93 & 3'b101) == 3'b101))) begin
-        _zz_94 = (! execute_SRC_LESS);
-    end else begin
-        _zz_94 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_95 = 1'b0;
-      end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_95 = 1'b1;
-      end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_95 = 1'b1;
-      end
-      default : begin
-        _zz_95 = _zz_94;
-      end
-    endcase
-  end
-
-  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_96 = _zz_201[19];
-  always @ (*) begin
-    _zz_97[10] = _zz_96;
-    _zz_97[9] = _zz_96;
-    _zz_97[8] = _zz_96;
-    _zz_97[7] = _zz_96;
-    _zz_97[6] = _zz_96;
-    _zz_97[5] = _zz_96;
-    _zz_97[4] = _zz_96;
-    _zz_97[3] = _zz_96;
-    _zz_97[2] = _zz_96;
-    _zz_97[1] = _zz_96;
-    _zz_97[0] = _zz_96;
-  end
-
-  assign _zz_98 = _zz_202[11];
+  assign _zz_98 = _zz_207[11];
   always @ (*) begin
     _zz_99[19] = _zz_98;
     _zz_99[18] = _zz_98;
@@ -2712,8 +2976,9 @@ module VexRiscv (
     _zz_99[0] = _zz_98;
   end
 
-  assign _zz_100 = _zz_203[11];
+  assign _zz_100 = _zz_208[11];
   always @ (*) begin
+    _zz_101[19] = _zz_100;
     _zz_101[18] = _zz_100;
     _zz_101[17] = _zz_100;
     _zz_101[16] = _zz_100;
@@ -2736,20 +3001,220 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_102 = {{_zz_97,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+    case(execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : begin
+        _zz_102 = execute_RS2;
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
+      `Src2CtrlEnum_defaultEncoding_IMI : begin
         _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
       end
+      `Src2CtrlEnum_defaultEncoding_IMS : begin
+        _zz_102 = {_zz_101,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+      end
       default : begin
-        _zz_102 = {{_zz_101,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_102 = _zz_39;
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_102;
+  always @ (*) begin
+    execute_SrcPlugin_addSub = _zz_209;
+    if(execute_SRC2_FORCE_ZERO)begin
+      execute_SrcPlugin_addSub = execute_SRC1;
+    end
+  end
+
+  assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
+  assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
+  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
+  always @ (*) begin
+    case(execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
+        _zz_103 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      end
+      default : begin
+        _zz_103 = _zz_216;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_104 = 1'b0;
+    if(_zz_106)begin
+      if((_zz_107 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_104 = 1'b1;
+      end
+    end
+    if(_zz_167)begin
+      if(_zz_168)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_104 = 1'b1;
+        end
+      end
+    end
+    if(_zz_169)begin
+      if(_zz_170)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_104 = 1'b1;
+        end
+      end
+    end
+    if(_zz_171)begin
+      if(_zz_172)begin
+        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_104 = 1'b1;
+        end
+      end
+    end
+    if((! decode_RS1_USE))begin
+      _zz_104 = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    _zz_105 = 1'b0;
+    if(_zz_106)begin
+      if((_zz_107 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_105 = 1'b1;
+      end
+    end
+    if(_zz_167)begin
+      if(_zz_168)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_105 = 1'b1;
+        end
+      end
+    end
+    if(_zz_169)begin
+      if(_zz_170)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_105 = 1'b1;
+        end
+      end
+    end
+    if(_zz_171)begin
+      if(_zz_172)begin
+        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_105 = 1'b1;
+        end
+      end
+    end
+    if((! decode_RS2_USE))begin
+      _zz_105 = 1'b0;
+    end
+  end
+
+  assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
+  assign _zz_108 = execute_INSTRUCTION[14 : 12];
+  always @ (*) begin
+    if((_zz_108 == 3'b000)) begin
+        _zz_109 = execute_BranchPlugin_eq;
+    end else if((_zz_108 == 3'b001)) begin
+        _zz_109 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_108 & 3'b101) == 3'b101))) begin
+        _zz_109 = (! execute_SRC_LESS);
+    end else begin
+        _zz_109 = execute_SRC_LESS;
+    end
+  end
+
+  always @ (*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_110 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_110 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_110 = 1'b1;
+      end
+      default : begin
+        _zz_110 = _zz_109;
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
+  assign _zz_111 = _zz_218[19];
+  always @ (*) begin
+    _zz_112[10] = _zz_111;
+    _zz_112[9] = _zz_111;
+    _zz_112[8] = _zz_111;
+    _zz_112[7] = _zz_111;
+    _zz_112[6] = _zz_111;
+    _zz_112[5] = _zz_111;
+    _zz_112[4] = _zz_111;
+    _zz_112[3] = _zz_111;
+    _zz_112[2] = _zz_111;
+    _zz_112[1] = _zz_111;
+    _zz_112[0] = _zz_111;
+  end
+
+  assign _zz_113 = _zz_219[11];
+  always @ (*) begin
+    _zz_114[19] = _zz_113;
+    _zz_114[18] = _zz_113;
+    _zz_114[17] = _zz_113;
+    _zz_114[16] = _zz_113;
+    _zz_114[15] = _zz_113;
+    _zz_114[14] = _zz_113;
+    _zz_114[13] = _zz_113;
+    _zz_114[12] = _zz_113;
+    _zz_114[11] = _zz_113;
+    _zz_114[10] = _zz_113;
+    _zz_114[9] = _zz_113;
+    _zz_114[8] = _zz_113;
+    _zz_114[7] = _zz_113;
+    _zz_114[6] = _zz_113;
+    _zz_114[5] = _zz_113;
+    _zz_114[4] = _zz_113;
+    _zz_114[3] = _zz_113;
+    _zz_114[2] = _zz_113;
+    _zz_114[1] = _zz_113;
+    _zz_114[0] = _zz_113;
+  end
+
+  assign _zz_115 = _zz_220[11];
+  always @ (*) begin
+    _zz_116[18] = _zz_115;
+    _zz_116[17] = _zz_115;
+    _zz_116[16] = _zz_115;
+    _zz_116[15] = _zz_115;
+    _zz_116[14] = _zz_115;
+    _zz_116[13] = _zz_115;
+    _zz_116[12] = _zz_115;
+    _zz_116[11] = _zz_115;
+    _zz_116[10] = _zz_115;
+    _zz_116[9] = _zz_115;
+    _zz_116[8] = _zz_115;
+    _zz_116[7] = _zz_115;
+    _zz_116[6] = _zz_115;
+    _zz_116[5] = _zz_115;
+    _zz_116[4] = _zz_115;
+    _zz_116[3] = _zz_115;
+    _zz_116[2] = _zz_115;
+    _zz_116[1] = _zz_115;
+    _zz_116[0] = _zz_115;
+  end
+
+  always @ (*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_117 = {{_zz_112,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_117 = {_zz_114,execute_INSTRUCTION[31 : 20]};
+      end
+      default : begin
+        _zz_117 = {{_zz_116,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_branch_src2 = _zz_117;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
@@ -2762,16 +3227,13 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_103 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_104 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_105 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_118 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_119 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_120 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_106 = {CfuPlugin_joinException_valid,{CsrPlugin_selfException_valid,DBusSimplePlugin_memoryExceptionPort_valid}};
-  assign _zz_107 = (_zz_106 & (~ _zz_204));
-  assign _zz_108 = _zz_107[1];
-  assign _zz_109 = _zz_107[2];
-  assign _zz_110 = {_zz_109,_zz_108};
+  assign _zz_121 = {CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_122 = _zz_221[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
     if(decodeExceptionPort_valid)begin
@@ -2784,7 +3246,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(_zz_152)begin
+    if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -2792,14 +3254,33 @@ module VexRiscv (
     end
   end
 
+  always @ (*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+    if(_zz_162)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
+    end
+    if(memory_arbitration_isFlushed)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+    if(writeBack_arbitration_isFlushed)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
+    end
+  end
+
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-  assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && CsrPlugin_allowException);
+  assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
-    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_0;
-    if((CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute != 1'b0))begin
+    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -2845,7 +3326,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = (1'b0 || 1'b0);
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -2893,7 +3374,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_159)begin
+    if(_zz_173)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -2912,14 +3393,14 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_160)begin
+    if(_zz_174)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_160)begin
+    if(_zz_174)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -2934,14 +3415,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_159)begin
+    if(_zz_173)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_159)begin
+    if(_zz_173)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -2950,7 +3431,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_169)
+    case(_zz_184)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -2963,58 +3444,58 @@ module VexRiscv (
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign execute_CfuPlugin_functionsIds_0 = _zz_205;
+  assign execute_CfuPlugin_functionsIds_0 = _zz_223;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
-  assign _zz_111 = _zz_206[7];
+  assign _zz_123 = _zz_224[7];
   always @ (*) begin
-    _zz_112[23] = _zz_111;
-    _zz_112[22] = _zz_111;
-    _zz_112[21] = _zz_111;
-    _zz_112[20] = _zz_111;
-    _zz_112[19] = _zz_111;
-    _zz_112[18] = _zz_111;
-    _zz_112[17] = _zz_111;
-    _zz_112[16] = _zz_111;
-    _zz_112[15] = _zz_111;
-    _zz_112[14] = _zz_111;
-    _zz_112[13] = _zz_111;
-    _zz_112[12] = _zz_111;
-    _zz_112[11] = _zz_111;
-    _zz_112[10] = _zz_111;
-    _zz_112[9] = _zz_111;
-    _zz_112[8] = _zz_111;
-    _zz_112[7] = _zz_111;
-    _zz_112[6] = _zz_111;
-    _zz_112[5] = _zz_111;
-    _zz_112[4] = _zz_111;
-    _zz_112[3] = _zz_111;
-    _zz_112[2] = _zz_111;
-    _zz_112[1] = _zz_111;
-    _zz_112[0] = _zz_111;
+    _zz_124[23] = _zz_123;
+    _zz_124[22] = _zz_123;
+    _zz_124[21] = _zz_123;
+    _zz_124[20] = _zz_123;
+    _zz_124[19] = _zz_123;
+    _zz_124[18] = _zz_123;
+    _zz_124[17] = _zz_123;
+    _zz_124[16] = _zz_123;
+    _zz_124[15] = _zz_123;
+    _zz_124[14] = _zz_123;
+    _zz_124[13] = _zz_123;
+    _zz_124[12] = _zz_123;
+    _zz_124[11] = _zz_123;
+    _zz_124[10] = _zz_123;
+    _zz_124[9] = _zz_123;
+    _zz_124[8] = _zz_123;
+    _zz_124[7] = _zz_123;
+    _zz_124[6] = _zz_123;
+    _zz_124[5] = _zz_123;
+    _zz_124[4] = _zz_123;
+    _zz_124[3] = _zz_123;
+    _zz_124[2] = _zz_123;
+    _zz_124[1] = _zz_123;
+    _zz_124[0] = _zz_123;
   end
 
   always @ (*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
       `Input2Kind_defaultEncoding_RS : begin
-        _zz_113 = execute_RS2;
+        _zz_125 = execute_RS2;
       end
       default : begin
-        _zz_113 = {_zz_112,execute_INSTRUCTION[31 : 24]};
+        _zz_125 = {_zz_124,execute_INSTRUCTION[31 : 24]};
       end
     endcase
   end
 
-  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_113;
-  assign execute_CfuPlugin_rsp_valid = CfuPlugin_bus_rsp_valid;
-  assign CfuPlugin_bus_rsp_ready = execute_CfuPlugin_rsp_ready;
-  assign execute_CfuPlugin_rsp_payload_response_ok = CfuPlugin_bus_rsp_payload_response_ok;
-  assign execute_CfuPlugin_rsp_payload_outputs_0 = CfuPlugin_bus_rsp_payload_outputs_0;
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_125;
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @ (*) begin
     CfuPlugin_joinException_valid = 1'b0;
-    if(execute_CfuPlugin_CFU_IN_FLIGHT)begin
-      if(execute_arbitration_isValid)begin
-        CfuPlugin_joinException_valid = (! execute_CfuPlugin_rsp_payload_response_ok);
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if(memory_arbitration_isValid)begin
+        CfuPlugin_joinException_valid = (! memory_CfuPlugin_rsp_payload_response_ok);
       end
     end
   end
@@ -3022,180 +3503,199 @@ module VexRiscv (
   assign CfuPlugin_joinException_payload_code = 4'b1111;
   assign CfuPlugin_joinException_payload_badAddr = 32'h0;
   always @ (*) begin
-    execute_CfuPlugin_rsp_ready = 1'b0;
-    if(execute_CfuPlugin_CFU_IN_FLIGHT)begin
-      execute_CfuPlugin_rsp_ready = (! execute_arbitration_isStuckByOthers);
+    memory_CfuPlugin_rsp_ready = 1'b0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
+  assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @ (*) begin
-    execute_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_148)begin
-      if(_zz_151)begin
-        execute_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
+    memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
+    if(_zz_156)begin
+      if(_zz_161)begin
+        memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
   end
 
   always @ (*) begin
-    execute_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! execute_arbitration_isStuck))begin
-      execute_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
+    memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
+    if((! memory_arbitration_isStuck))begin
+      memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
     end
   end
 
-  assign execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (execute_MulDivIterativePlugin_mul_counter_value == 6'h20);
-  assign execute_MulDivIterativePlugin_mul_counter_willOverflow = (execute_MulDivIterativePlugin_mul_counter_willOverflowIfInc && execute_MulDivIterativePlugin_mul_counter_willIncrement);
+  assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
+  assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @ (*) begin
-    if(execute_MulDivIterativePlugin_mul_counter_willOverflow)begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = (execute_MulDivIterativePlugin_mul_counter_value + _zz_208);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_226);
     end
-    if(execute_MulDivIterativePlugin_mul_counter_willClear)begin
-      execute_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_114 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_115 = ((execute_IS_MUL && _zz_114) || 1'b0);
+  assign _zz_126 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_127 = ((execute_IS_MUL && _zz_126) || 1'b0);
   always @ (*) begin
-    _zz_116[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_116[31 : 0] = execute_RS1;
+    _zz_128[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_128[31 : 0] = execute_RS1;
   end
 
-  assign _zz_118 = (_zz_117 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_118 != 32'h0);
-  assign _zz_27 = _zz_40;
-  assign _zz_25 = _zz_39;
-  assign _zz_18 = decode_ALU_CTRL;
-  assign _zz_16 = _zz_38;
-  assign _zz_28 = decode_to_execute_ALU_CTRL;
-  assign _zz_15 = decode_ALU_BITWISE_CTRL;
-  assign _zz_13 = _zz_37;
-  assign _zz_29 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_12 = decode_SHIFT_CTRL;
-  assign _zz_10 = _zz_36;
-  assign _zz_22 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_7 = _zz_35;
-  assign _zz_21 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_6 = decode_ENV_CTRL;
-  assign _zz_4 = _zz_34;
-  assign _zz_20 = decode_to_execute_ENV_CTRL;
+  assign _zz_130 = (_zz_129 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_130 != 32'h0);
+  assign _zz_28 = decode_SRC1_CTRL;
+  assign _zz_26 = _zz_54;
+  assign _zz_41 = decode_to_execute_SRC1_CTRL;
+  assign _zz_25 = decode_SRC2_CTRL;
+  assign _zz_23 = _zz_53;
+  assign _zz_40 = decode_to_execute_SRC2_CTRL;
+  assign _zz_22 = decode_ALU_CTRL;
+  assign _zz_20 = _zz_52;
+  assign _zz_42 = decode_to_execute_ALU_CTRL;
+  assign _zz_19 = decode_ALU_BITWISE_CTRL;
+  assign _zz_17 = _zz_51;
+  assign _zz_43 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_16 = decode_SHIFT_CTRL;
+  assign _zz_14 = _zz_50;
+  assign _zz_38 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_13 = decode_BRANCH_CTRL;
+  assign _zz_11 = _zz_49;
+  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_10 = decode_ENV_CTRL;
+  assign _zz_7 = execute_ENV_CTRL;
+  assign _zz_5 = memory_ENV_CTRL;
+  assign _zz_8 = _zz_48;
+  assign _zz_34 = decode_to_execute_ENV_CTRL;
+  assign _zz_33 = execute_to_memory_ENV_CTRL;
+  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
   assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_1 = _zz_33;
-  assign _zz_19 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign decode_arbitration_isFlushed = ((execute_arbitration_flushNext != 1'b0) || ({execute_arbitration_flushIt,decode_arbitration_flushIt} != 2'b00));
-  assign execute_arbitration_isFlushed = (1'b0 || (execute_arbitration_flushIt != 1'b0));
-  assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (1'b0 || execute_arbitration_isStuck));
+  assign _zz_1 = _zz_47;
+  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
+  assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
   assign decode_arbitration_isFiring = ((decode_arbitration_isValid && (! decode_arbitration_isStuck)) && (! decode_arbitration_removeIt));
-  assign execute_arbitration_isStuckByOthers = (execute_arbitration_haltByOther || 1'b0);
+  assign execute_arbitration_isStuckByOthers = (execute_arbitration_haltByOther || ((1'b0 || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign execute_arbitration_isStuck = (execute_arbitration_haltItself || execute_arbitration_isStuckByOthers);
   assign execute_arbitration_isMoving = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign execute_arbitration_isFiring = ((execute_arbitration_isValid && (! execute_arbitration_isStuck)) && (! execute_arbitration_removeIt));
+  assign memory_arbitration_isStuckByOthers = (memory_arbitration_haltByOther || (1'b0 || writeBack_arbitration_isStuck));
+  assign memory_arbitration_isStuck = (memory_arbitration_haltItself || memory_arbitration_isStuckByOthers);
+  assign memory_arbitration_isMoving = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign memory_arbitration_isFiring = ((memory_arbitration_isValid && (! memory_arbitration_isStuck)) && (! memory_arbitration_removeIt));
+  assign writeBack_arbitration_isStuckByOthers = (writeBack_arbitration_haltByOther || 1'b0);
+  assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
+  assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
+  assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_119 = 32'h0;
+    _zz_131 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_119[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_119[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_119[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_131[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_131[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_131[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_120 = 32'h0;
+    _zz_132 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_120[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_120[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_120[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_132[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_132[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_132[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_121 = 32'h0;
+    _zz_133 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_121[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_121[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_121[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_133[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_133[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_133[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_122 = 32'h0;
+    _zz_134 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_122[31 : 0] = CsrPlugin_mepc;
+      _zz_134[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_123 = 32'h0;
+    _zz_135 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_123[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_123[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_135[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_135[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_124 = 32'h0;
+    _zz_136 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_124[31 : 0] = CsrPlugin_mtval;
+      _zz_136[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_125 = 32'h0;
+    _zz_137 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_125[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_137[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_126 = 32'h0;
+    _zz_138 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_126[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_138[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_127 = 32'h0;
+    _zz_139 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_127[31 : 0] = _zz_117;
+      _zz_139[31 : 0] = _zz_129;
     end
   end
 
   always @ (*) begin
-    _zz_128 = 32'h0;
+    _zz_140 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_128[31 : 0] = _zz_118;
+      _zz_140[31 : 0] = _zz_130;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_119 | _zz_120) | (_zz_121 | _zz_122)) | ((_zz_123 | _zz_124) | (_zz_125 | _zz_126))) | (_zz_127 | _zz_128));
-  assign iBusWishbone_ADR = {_zz_225,_zz_129};
-  assign iBusWishbone_CTI = ((_zz_129 == 3'b111) ? 3'b111 : 3'b010);
+  assign execute_CsrPlugin_readData = ((((_zz_131 | _zz_132) | (_zz_133 | _zz_134)) | ((_zz_135 | _zz_136) | (_zz_137 | _zz_138))) | (_zz_139 | _zz_140));
+  assign iBusWishbone_ADR = {_zz_243,_zz_141};
+  assign iBusWishbone_CTI = ((_zz_141 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_161)begin
+    if(_zz_175)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_161)begin
+    if(_zz_175)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_130;
+  assign iBus_rsp_valid = _zz_142;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -3210,19 +3710,19 @@ module VexRiscv (
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_131 = 4'b0001;
+        _zz_143 = 4'b0001;
       end
       2'b01 : begin
-        _zz_131 = 4'b0011;
+        _zz_143 = 4'b0011;
       end
       default : begin
-        _zz_131 = 4'b1111;
+        _zz_143 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_131 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_143 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
       dBusWishbone_SEL = 4'b1111;
     end
@@ -3242,17 +3742,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_51 <= 1'b0;
-      _zz_53 <= 1'b0;
+      _zz_67 <= 1'b0;
+      _zz_69 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_55;
+      IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      IBusCachedPlugin_rspCounter <= _zz_71;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_56 <= 1'b0;
-      _zz_80 <= 1'b1;
+      _zz_95 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_91 <= 1'b0;
+      _zz_106 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3261,18 +3762,25 @@ module VexRiscv (
       CsrPlugin_mie_MSIE <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       CsrPlugin_interrupt_valid <= 1'b0;
       CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
-      execute_MulDivIterativePlugin_frontendOk <= 1'b0;
-      execute_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      _zz_117 <= 32'h0;
+      CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
+      _zz_129 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
-      _zz_129 <= 3'b000;
-      _zz_130 <= 1'b0;
+      memory_arbitration_isValid <= 1'b0;
+      writeBack_arbitration_isValid <= 1'b0;
+      execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
+      _zz_141 <= 3'b000;
+      _zz_142 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -3296,16 +3804,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_51 <= 1'b0;
+        _zz_67 <= 1'b0;
       end
-      if(_zz_49)begin
-        _zz_51 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_65)begin
+        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_53 <= 1'b0;
+        _zz_69 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_53 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_69 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3331,18 +3839,50 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      end
+      if((! memory_arbitration_isStuck))begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      end
+      if((! writeBack_arbitration_isStuck))begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
+      end
+      if(IBusCachedPlugin_fetchPc_flushed)begin
+        IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
+      end
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if((dBus_cmd_valid && dBus_cmd_ready))begin
-        _zz_56 <= 1'b1;
-      end
-      if((! execute_arbitration_isStuck))begin
-        _zz_56 <= 1'b0;
-      end
-      _zz_80 <= 1'b0;
-      if(_zz_146)begin
-        if(_zz_162)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_95 <= 1'b0;
+      if(_zz_157)begin
+        if(_zz_176)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3352,7 +3892,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_91 <= (_zz_31 && execute_arbitration_isFiring);
+      _zz_106 <= (_zz_45 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3361,17 +3901,27 @@ module VexRiscv (
       if((! execute_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
-        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+      end
+      if((! memory_arbitration_isStuck))begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+      end
+      if((! writeBack_arbitration_isStuck))begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_163)begin
-        if(_zz_164)begin
+      if(_zz_177)begin
+        if(_zz_178)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_165)begin
+        if(_zz_179)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_166)begin
+        if(_zz_180)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3379,15 +3929,23 @@ module VexRiscv (
         if((! execute_arbitration_isStuck))begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
+        if((! memory_arbitration_isStuck))begin
+          CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
+        end
+        if((! writeBack_arbitration_isStuck))begin
+          CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
+        end
       end
       if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
       if(CsrPlugin_interruptJump)begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_153)begin
+      if(_zz_163)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3398,8 +3956,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_154)begin
-        case(_zz_155)
+      if(_zz_164)begin
+        case(_zz_165)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3409,7 +3967,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_105,{_zz_104,_zz_103}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_120,{_zz_119,_zz_118}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(execute_CfuPlugin_schedule)begin
         execute_CfuPlugin_hold <= 1'b1;
       end
@@ -3422,45 +3980,60 @@ module VexRiscv (
       if((! execute_arbitration_isStuckByOthers))begin
         execute_CfuPlugin_fired <= 1'b0;
       end
-      if(((execute_arbitration_isValid && (! 1'b0)) && (1'b0 || execute_IS_MUL)))begin
-        execute_MulDivIterativePlugin_frontendOk <= 1'b1;
+      if(memory_CfuPlugin_rsp_ready)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       end
-      if(execute_arbitration_isMoving)begin
-        execute_MulDivIterativePlugin_frontendOk <= 1'b0;
+      if(_zz_181)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
       end
-      execute_MulDivIterativePlugin_mul_counter_value <= execute_MulDivIterativePlugin_mul_counter_valueNext;
+      memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
+      if((! memory_arbitration_isStuck))begin
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
+      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
       if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
+      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+        memory_arbitration_isValid <= 1'b0;
+      end
+      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+        memory_arbitration_isValid <= execute_arbitration_isValid;
+      end
+      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+        writeBack_arbitration_isValid <= 1'b0;
+      end
+      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+        writeBack_arbitration_isValid <= memory_arbitration_isValid;
+      end
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_219[0];
-          CsrPlugin_mstatus_MIE <= _zz_220[0];
+          CsrPlugin_mstatus_MPIE <= _zz_237[0];
+          CsrPlugin_mstatus_MIE <= _zz_238[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_222[0];
-          CsrPlugin_mie_MTIE <= _zz_223[0];
-          CsrPlugin_mie_MSIE <= _zz_224[0];
+          CsrPlugin_mie_MEIE <= _zz_240[0];
+          CsrPlugin_mie_MTIE <= _zz_241[0];
+          CsrPlugin_mie_MSIE <= _zz_242[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_117 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_129 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_161)begin
+      if(_zz_175)begin
         if(iBusWishbone_ACK)begin
-          _zz_129 <= (_zz_129 + 3'b001);
+          _zz_141 <= (_zz_141 + 3'b001);
         end
       end
-      _zz_130 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_167)begin
+      _zz_142 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_182)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3472,7 +4045,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_54 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_70 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -3480,50 +4053,51 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if((! execute_arbitration_isStuckByOthers))begin
-      execute_LightShifterPlugin_shiftReg <= _zz_41;
-    end
-    if(_zz_146)begin
-      if(_zz_162)begin
+    if(_zz_157)begin
+      if(_zz_176)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_92 <= _zz_30[11 : 7];
+    _zz_107 <= _zz_44[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(execute_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
     if(decodeExceptionPort_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
-    if(_zz_152)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= _zz_144;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= _zz_145;
+    if(CsrPlugin_selfException_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_163)begin
-      if(_zz_164)begin
+    if(_zz_162)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_122 ? DBusSimplePlugin_memoryExceptionPort_payload_code : CfuPlugin_joinException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_122 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : CfuPlugin_joinException_payload_badAddr);
+    end
+    if(_zz_177)begin
+      if(_zz_178)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_165)begin
+      if(_zz_179)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_166)begin
+      if(_zz_180)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_153)begin
+    if(_zz_163)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= execute_PC;
+          CsrPlugin_mepc <= writeBack_PC;
           if(CsrPlugin_hadException)begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
@@ -3532,26 +4106,51 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_148)begin
-      if(_zz_151)begin
-        execute_MulDivIterativePlugin_rs2 <= (execute_MulDivIterativePlugin_rs2 >>> 1);
-        execute_MulDivIterativePlugin_accumulator <= ({_zz_209,execute_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+    if(_zz_181)begin
+      CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
+      CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
+    end
+    if(_zz_156)begin
+      if(_zz_161)begin
+        memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_227,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
-    if((! execute_MulDivIterativePlugin_frontendOk))begin
-      execute_MulDivIterativePlugin_accumulator <= 65'h0;
-      execute_MulDivIterativePlugin_rs1 <= ((_zz_115 ? (~ _zz_116) : _zz_116) + _zz_216);
-      execute_MulDivIterativePlugin_rs2 <= ((_zz_114 ? (~ execute_RS2) : execute_RS2) + _zz_218);
+    if((! memory_arbitration_isStuck))begin
+      memory_MulDivIterativePlugin_accumulator <= 65'h0;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_127 ? (~ _zz_128) : _zz_128) + _zz_234);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_126 ? (~ execute_RS2) : execute_RS2) + _zz_236);
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if(((! execute_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_execute)))begin
-      decode_to_execute_PC <= _zz_23;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PC <= decode_PC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_PC <= _zz_39;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_56;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_57;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_27;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -3559,32 +4158,68 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_24;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
+    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_17;
+      decode_to_execute_ALU_CTRL <= _zz_21;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_14;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_18;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_11;
+      decode_to_execute_SHIFT_CTRL <= _zz_15;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+      decode_to_execute_BRANCH_CTRL <= _zz_12;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_5;
+      decode_to_execute_ENV_CTRL <= _zz_9;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_6;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_4;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
@@ -3595,6 +4230,9 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
@@ -3602,25 +4240,51 @@ module VexRiscv (
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= _zz_26;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= _zz_24;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1 <= decode_SRC1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2 <= decode_SRC2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MMU_RSP2_physicalAddress <= execute_MMU_RSP2_physicalAddress;
+      execute_to_memory_MMU_RSP2_isIoAccess <= execute_MMU_RSP2_isIoAccess;
+      execute_to_memory_MMU_RSP2_isPaging <= execute_MMU_RSP2_isPaging;
+      execute_to_memory_MMU_RSP2_allowRead <= execute_MMU_RSP2_allowRead;
+      execute_to_memory_MMU_RSP2_allowWrite <= execute_MMU_RSP2_allowWrite;
+      execute_to_memory_MMU_RSP2_allowExecute <= execute_MMU_RSP2_allowExecute;
+      execute_to_memory_MMU_RSP2_exception <= execute_MMU_RSP2_exception;
+      execute_to_memory_MMU_RSP2_refilling <= execute_MMU_RSP2_refilling;
+      execute_to_memory_MMU_RSP2_bypassTranslation <= execute_MMU_RSP2_bypassTranslation;
+    end
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_29;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -3657,7 +4321,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_221[0];
+        CsrPlugin_mip_MSIP <= _zz_239[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -3672,7 +4336,7 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_167)begin
+    if(_zz_182)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -90,6 +90,10 @@ object GenCoreDefault{
     val argConfig = parser.parse(args, ArgConfig()).get
     val linux = argConfig.csrPluginConfig.startsWith("linux")
 
+    if (!argConfig.memoryAndWritebackStage && argConfig.cfu) {
+      throw new RuntimeException("CFU plugin requires a memory and writeback stage.")
+    }
+
     SpinalConfig.copy(netlistFileName = argConfig.outputFile + ".v").generateVerilog {
       // Generate CPU plugin list
       val plugins = ArrayBuffer[Plugin[VexRiscv]]()


### PR DESCRIPTION
The CFU plugin will hang without a memory and writeback stage. This PR not only changes the `VexRiscv_Fomu[Cfu].v` builds to conform to this rule, it also adds a check in the generation code to make sure an invalid variant cannot be made. 