### PR TITLE
Update the Fomu CPU Variant for performance.

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/Makefile
+++ b/pythondata_cpu_vexriscv/verilog/Makefile
@@ -27,10 +27,10 @@ VexRiscv_MinDebug.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault -d --iCacheSize 0 --dCacheSize 0 --mulDiv false --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --outputFile VexRiscv_MinDebug"
 
 VexRiscv_Fomu.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --safe false --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --hardwareDiv false --outputFile VexRiscv_Fomu"
+	sbt compile "runMain vexriscv.GenCoreDefault --safe false --iCacheSize 2048 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift true --singleCycleMulDiv true --bypass false --prediction none --hardwareDiv false --outputFile VexRiscv_Fomu"
 
 VexRiscv_FomuCfu.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --safe false --cfu true --iCacheSize 512 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none  --hardwareDiv false --outputFile VexRiscv_FomuCfu"
+	sbt compile "runMain vexriscv.GenCoreDefault --safe false --cfu true --iCacheSize 2048 --dCacheSize 0 --csrPluginConfig mcycle --mulDiv true --singleCycleShift true --singleCycleMulDiv true --bypass false --prediction none --hardwareDiv false --outputFile VexRiscv_FomuCfu"
 
 VexRiscv_Full.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all --outputFile VexRiscv_Full"

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.v
@@ -1,6 +1,6 @@
 // Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
-// Git hash  : 43e13174d8583db5f4cd45d2b3515bc206a0010a
+// Git hash  : d8ec2d84c3160c3a9131beef2db359dce7a2e4a4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -73,6 +73,7 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  wire                _zz_128;
   wire                _zz_129;
   wire                _zz_130;
   wire                _zz_131;
@@ -80,11 +81,10 @@ module VexRiscv (
   wire                _zz_133;
   wire                _zz_134;
   wire                _zz_135;
-  wire                _zz_136;
-  reg                 _zz_137;
+  reg                 _zz_136;
+  reg        [31:0]   _zz_137;
   reg        [31:0]   _zz_138;
   reg        [31:0]   _zz_139;
-  reg        [31:0]   _zz_140;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -97,230 +97,255 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
+  wire                _zz_140;
   wire                _zz_141;
   wire                _zz_142;
   wire                _zz_143;
   wire                _zz_144;
-  wire                _zz_145;
+  wire       [1:0]    _zz_145;
   wire                _zz_146;
   wire                _zz_147;
   wire                _zz_148;
-  wire       [1:0]    _zz_149;
+  wire                _zz_149;
   wire                _zz_150;
   wire                _zz_151;
   wire                _zz_152;
   wire                _zz_153;
   wire                _zz_154;
-  wire                _zz_155;
+  wire       [1:0]    _zz_155;
   wire                _zz_156;
   wire                _zz_157;
   wire                _zz_158;
   wire                _zz_159;
   wire                _zz_160;
   wire                _zz_161;
-  wire                _zz_162;
+  wire       [1:0]    _zz_162;
   wire                _zz_163;
-  wire                _zz_164;
-  wire                _zz_165;
-  wire       [1:0]    _zz_166;
-  wire                _zz_167;
-  wire       [0:0]    _zz_168;
-  wire       [0:0]    _zz_169;
-  wire       [0:0]    _zz_170;
-  wire       [0:0]    _zz_171;
-  wire       [0:0]    _zz_172;
-  wire       [0:0]    _zz_173;
-  wire       [0:0]    _zz_174;
-  wire       [0:0]    _zz_175;
-  wire       [0:0]    _zz_176;
+  wire       [1:0]    _zz_164;
+  wire       [51:0]   _zz_165;
+  wire       [51:0]   _zz_166;
+  wire       [51:0]   _zz_167;
+  wire       [32:0]   _zz_168;
+  wire       [51:0]   _zz_169;
+  wire       [49:0]   _zz_170;
+  wire       [51:0]   _zz_171;
+  wire       [49:0]   _zz_172;
+  wire       [51:0]   _zz_173;
+  wire       [32:0]   _zz_174;
+  wire       [31:0]   _zz_175;
+  wire       [32:0]   _zz_176;
   wire       [0:0]    _zz_177;
   wire       [0:0]    _zz_178;
   wire       [0:0]    _zz_179;
   wire       [0:0]    _zz_180;
   wire       [0:0]    _zz_181;
   wire       [0:0]    _zz_182;
-  wire       [2:0]    _zz_183;
-  wire       [2:0]    _zz_184;
-  wire       [31:0]   _zz_185;
+  wire       [0:0]    _zz_183;
+  wire       [0:0]    _zz_184;
+  wire       [0:0]    _zz_185;
   wire       [0:0]    _zz_186;
-  wire       [2:0]    _zz_187;
-  wire       [4:0]    _zz_188;
-  wire       [11:0]   _zz_189;
-  wire       [11:0]   _zz_190;
-  wire       [31:0]   _zz_191;
+  wire       [0:0]    _zz_187;
+  wire       [0:0]    _zz_188;
+  wire       [0:0]    _zz_189;
+  wire       [2:0]    _zz_190;
+  wire       [2:0]    _zz_191;
   wire       [31:0]   _zz_192;
-  wire       [31:0]   _zz_193;
-  wire       [31:0]   _zz_194;
-  wire       [31:0]   _zz_195;
-  wire       [31:0]   _zz_196;
-  wire       [31:0]   _zz_197;
+  wire       [0:0]    _zz_193;
+  wire       [2:0]    _zz_194;
+  wire       [4:0]    _zz_195;
+  wire       [11:0]   _zz_196;
+  wire       [11:0]   _zz_197;
   wire       [31:0]   _zz_198;
-  wire       [32:0]   _zz_199;
-  wire       [19:0]   _zz_200;
-  wire       [11:0]   _zz_201;
-  wire       [11:0]   _zz_202;
-  wire       [0:0]    _zz_203;
-  wire       [5:0]    _zz_204;
-  wire       [33:0]   _zz_205;
-  wire       [32:0]   _zz_206;
-  wire       [33:0]   _zz_207;
-  wire       [32:0]   _zz_208;
-  wire       [33:0]   _zz_209;
-  wire       [32:0]   _zz_210;
-  wire       [0:0]    _zz_211;
-  wire       [32:0]   _zz_212;
+  wire       [31:0]   _zz_199;
+  wire       [31:0]   _zz_200;
+  wire       [31:0]   _zz_201;
+  wire       [31:0]   _zz_202;
+  wire       [31:0]   _zz_203;
+  wire       [31:0]   _zz_204;
+  wire       [19:0]   _zz_205;
+  wire       [11:0]   _zz_206;
+  wire       [11:0]   _zz_207;
+  wire       [65:0]   _zz_208;
+  wire       [65:0]   _zz_209;
+  wire       [31:0]   _zz_210;
+  wire       [31:0]   _zz_211;
+  wire       [0:0]    _zz_212;
   wire       [0:0]    _zz_213;
-  wire       [31:0]   _zz_214;
+  wire       [0:0]    _zz_214;
   wire       [0:0]    _zz_215;
   wire       [0:0]    _zz_216;
   wire       [0:0]    _zz_217;
-  wire       [0:0]    _zz_218;
-  wire       [0:0]    _zz_219;
-  wire       [0:0]    _zz_220;
-  wire       [26:0]   _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire       [1:0]    _zz_224;
-  wire       [31:0]   _zz_225;
-  wire       [31:0]   _zz_226;
-  wire       [31:0]   _zz_227;
-  wire                _zz_228;
-  wire       [0:0]    _zz_229;
-  wire       [13:0]   _zz_230;
-  wire       [31:0]   _zz_231;
-  wire       [31:0]   _zz_232;
-  wire       [31:0]   _zz_233;
-  wire                _zz_234;
-  wire       [0:0]    _zz_235;
-  wire       [7:0]    _zz_236;
-  wire       [31:0]   _zz_237;
-  wire       [31:0]   _zz_238;
-  wire       [31:0]   _zz_239;
-  wire                _zz_240;
-  wire       [0:0]    _zz_241;
-  wire       [1:0]    _zz_242;
+  wire       [26:0]   _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire       [1:0]    _zz_221;
+  wire       [31:0]   _zz_222;
+  wire       [31:0]   _zz_223;
+  wire       [31:0]   _zz_224;
+  wire                _zz_225;
+  wire       [0:0]    _zz_226;
+  wire       [13:0]   _zz_227;
+  wire       [31:0]   _zz_228;
+  wire       [31:0]   _zz_229;
+  wire       [31:0]   _zz_230;
+  wire                _zz_231;
+  wire       [0:0]    _zz_232;
+  wire       [7:0]    _zz_233;
+  wire       [31:0]   _zz_234;
+  wire       [31:0]   _zz_235;
+  wire       [31:0]   _zz_236;
+  wire                _zz_237;
+  wire       [0:0]    _zz_238;
+  wire       [1:0]    _zz_239;
+  wire       [31:0]   _zz_240;
+  wire       [31:0]   _zz_241;
+  wire       [31:0]   _zz_242;
   wire                _zz_243;
-  wire       [0:0]    _zz_244;
-  wire       [0:0]    _zz_245;
+  wire       [1:0]    _zz_244;
+  wire       [1:0]    _zz_245;
   wire                _zz_246;
   wire       [0:0]    _zz_247;
-  wire       [23:0]   _zz_248;
+  wire       [21:0]   _zz_248;
   wire       [31:0]   _zz_249;
-  wire                _zz_250;
-  wire                _zz_251;
-  wire       [0:0]    _zz_252;
-  wire       [0:0]    _zz_253;
-  wire       [0:0]    _zz_254;
-  wire       [0:0]    _zz_255;
-  wire                _zz_256;
-  wire       [0:0]    _zz_257;
-  wire       [19:0]   _zz_258;
-  wire       [31:0]   _zz_259;
+  wire       [31:0]   _zz_250;
+  wire       [31:0]   _zz_251;
+  wire       [31:0]   _zz_252;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire       [1:0]    _zz_255;
+  wire       [1:0]    _zz_256;
+  wire                _zz_257;
+  wire       [0:0]    _zz_258;
+  wire       [18:0]   _zz_259;
   wire       [31:0]   _zz_260;
-  wire                _zz_261;
-  wire                _zz_262;
-  wire                _zz_263;
-  wire       [2:0]    _zz_264;
-  wire       [2:0]    _zz_265;
-  wire                _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [16:0]   _zz_268;
-  wire       [31:0]   _zz_269;
-  wire       [31:0]   _zz_270;
-  wire                _zz_271;
-  wire                _zz_272;
-  wire                _zz_273;
-  wire       [0:0]    _zz_274;
-  wire       [0:0]    _zz_275;
-  wire                _zz_276;
-  wire       [0:0]    _zz_277;
-  wire       [0:0]    _zz_278;
-  wire                _zz_279;
-  wire       [0:0]    _zz_280;
-  wire       [13:0]   _zz_281;
-  wire       [31:0]   _zz_282;
-  wire       [31:0]   _zz_283;
+  wire       [31:0]   _zz_261;
+  wire       [31:0]   _zz_262;
+  wire       [31:0]   _zz_263;
+  wire       [31:0]   _zz_264;
+  wire       [31:0]   _zz_265;
+  wire       [0:0]    _zz_266;
+  wire       [1:0]    _zz_267;
+  wire       [0:0]    _zz_268;
+  wire       [0:0]    _zz_269;
+  wire                _zz_270;
+  wire       [0:0]    _zz_271;
+  wire       [15:0]   _zz_272;
+  wire       [31:0]   _zz_273;
+  wire       [31:0]   _zz_274;
+  wire       [31:0]   _zz_275;
+  wire       [31:0]   _zz_276;
+  wire       [31:0]   _zz_277;
+  wire       [31:0]   _zz_278;
+  wire       [31:0]   _zz_279;
+  wire       [31:0]   _zz_280;
+  wire                _zz_281;
+  wire       [1:0]    _zz_282;
+  wire       [1:0]    _zz_283;
   wire                _zz_284;
-  wire                _zz_285;
-  wire       [0:0]    _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire                _zz_290;
-  wire       [0:0]    _zz_291;
-  wire       [10:0]   _zz_292;
-  wire       [31:0]   _zz_293;
-  wire       [31:0]   _zz_294;
+  wire       [0:0]    _zz_285;
+  wire       [12:0]   _zz_286;
+  wire       [31:0]   _zz_287;
+  wire       [31:0]   _zz_288;
+  wire       [31:0]   _zz_289;
+  wire       [31:0]   _zz_290;
+  wire       [31:0]   _zz_291;
+  wire       [31:0]   _zz_292;
+  wire       [1:0]    _zz_293;
+  wire       [1:0]    _zz_294;
   wire                _zz_295;
-  wire                _zz_296;
-  wire                _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire                _zz_300;
-  wire       [0:0]    _zz_301;
-  wire       [7:0]    _zz_302;
-  wire       [31:0]   _zz_303;
+  wire       [0:0]    _zz_296;
+  wire       [9:0]    _zz_297;
+  wire       [31:0]   _zz_298;
+  wire       [31:0]   _zz_299;
+  wire       [31:0]   _zz_300;
+  wire                _zz_301;
+  wire       [0:0]    _zz_302;
+  wire       [1:0]    _zz_303;
   wire       [0:0]    _zz_304;
-  wire       [0:0]    _zz_305;
-  wire       [0:0]    _zz_306;
-  wire       [4:0]    _zz_307;
-  wire       [1:0]    _zz_308;
-  wire       [1:0]    _zz_309;
-  wire                _zz_310;
-  wire       [0:0]    _zz_311;
-  wire       [4:0]    _zz_312;
+  wire       [3:0]    _zz_305;
+  wire       [5:0]    _zz_306;
+  wire       [5:0]    _zz_307;
+  wire                _zz_308;
+  wire       [0:0]    _zz_309;
+  wire       [5:0]    _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
   wire       [31:0]   _zz_313;
   wire       [31:0]   _zz_314;
   wire       [31:0]   _zz_315;
   wire       [31:0]   _zz_316;
   wire                _zz_317;
   wire       [0:0]    _zz_318;
-  wire       [1:0]    _zz_319;
-  wire       [31:0]   _zz_320;
-  wire       [31:0]   _zz_321;
-  wire                _zz_322;
-  wire       [0:0]    _zz_323;
-  wire       [2:0]    _zz_324;
+  wire       [0:0]    _zz_319;
+  wire                _zz_320;
+  wire       [0:0]    _zz_321;
+  wire       [2:0]    _zz_322;
+  wire                _zz_323;
+  wire       [0:0]    _zz_324;
   wire       [0:0]    _zz_325;
-  wire       [0:0]    _zz_326;
-  wire                _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [1:0]    _zz_329;
-  wire       [31:0]   _zz_330;
+  wire       [3:0]    _zz_326;
+  wire       [3:0]    _zz_327;
+  wire                _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [2:0]    _zz_330;
   wire       [31:0]   _zz_331;
   wire       [31:0]   _zz_332;
-  wire                _zz_333;
-  wire                _zz_334;
+  wire       [31:0]   _zz_333;
+  wire       [31:0]   _zz_334;
   wire       [31:0]   _zz_335;
   wire       [31:0]   _zz_336;
   wire       [31:0]   _zz_337;
-  wire                _zz_338;
-  wire       [0:0]    _zz_339;
+  wire       [31:0]   _zz_338;
+  wire                _zz_339;
   wire       [0:0]    _zz_340;
-  wire       [31:0]   _zz_341;
+  wire       [0:0]    _zz_341;
   wire       [31:0]   _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [1:0]    _zz_344;
-  wire       [1:0]    _zz_345;
-  wire       [1:0]    _zz_346;
-  wire                _zz_347;
+  wire       [31:0]   _zz_343;
+  wire       [31:0]   _zz_344;
+  wire                _zz_345;
+  wire       [0:0]    _zz_346;
+  wire       [1:0]    _zz_347;
   wire                _zz_348;
-  wire       [31:0]   _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  wire       [31:0]   _zz_353;
+  wire       [2:0]    _zz_349;
+  wire       [2:0]    _zz_350;
+  wire                _zz_351;
+  wire       [0:0]    _zz_352;
+  wire       [0:0]    _zz_353;
   wire       [31:0]   _zz_354;
   wire       [31:0]   _zz_355;
-  wire                _zz_356;
-  wire                _zz_357;
-  wire                _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [0:0]    _zz_360;
-  wire                _zz_361;
+  wire       [31:0]   _zz_356;
+  wire       [31:0]   _zz_357;
+  wire       [31:0]   _zz_358;
+  wire       [31:0]   _zz_359;
+  wire       [31:0]   _zz_360;
+  wire       [31:0]   _zz_361;
+  wire                _zz_362;
+  wire       [31:0]   _zz_363;
+  wire                _zz_364;
+  wire       [0:0]    _zz_365;
+  wire       [0:0]    _zz_366;
+  wire       [0:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [1:0]    _zz_369;
+  wire       [1:0]    _zz_370;
+  wire       [0:0]    _zz_371;
+  wire       [0:0]    _zz_372;
+  wire       [31:0]   _zz_373;
+  wire       [31:0]   _zz_374;
+  wire       [31:0]   _zz_375;
+  wire       [31:0]   _zz_376;
+  wire       [31:0]   _zz_377;
+  wire       [31:0]   _zz_378;
+  wire       [51:0]   memory_MUL_LOW;
   wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
@@ -330,8 +355,8 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_IS_RS1_SIGNED;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
   wire                decode_IS_MUL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
@@ -346,55 +371,59 @@ module VexRiscv (
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
   wire                decode_SRC_LESS_UNSIGNED;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_17;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_18;
   wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
   wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
   wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                execute_IS_RS1_SIGNED;
-  wire                execute_IS_MUL;
-  wire                execute_IS_RS2_SIGNED;
-  reg        [31:0]   _zz_26;
-  wire                memory_IS_MUL;
+  wire                writeBack_IS_MUL;
+  wire       [33:0]   writeBack_MUL_HH;
+  wire       [51:0]   writeBack_MUL_LOW;
+  wire       [33:0]   memory_MUL_HL;
+  wire       [33:0]   memory_MUL_LH;
+  wire       [31:0]   memory_MUL_LL;
+  reg        [31:0]   _zz_28;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
-  wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
-  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_31;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
-  wire       [31:0]   execute_RS1;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_32;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -403,42 +432,45 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_31;
+  wire       [31:0]   memory_SHIFT_RIGHT;
+  reg        [31:0]   _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_32;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_35;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_33;
+  wire       [31:0]   _zz_36;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_37;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_35;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_38;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_36;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_39;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_37;
-  wire       [31:0]   _zz_38;
-  wire                _zz_39;
-  reg                 _zz_40;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_40;
+  wire       [31:0]   _zz_41;
+  wire                _zz_42;
+  reg                 _zz_43;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_41;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_42;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_49;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_50;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_48;
+  reg        [31:0]   _zz_51;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -467,7 +499,7 @@ module VexRiscv (
   wire                execute_MMU_RSP2_refilling;
   wire                execute_MMU_RSP2_bypassTranslation;
   wire       [31:0]   execute_SRC_ADD;
-  wire       [31:0]   execute_RS2;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
@@ -477,7 +509,7 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_49;
+  reg        [31:0]   _zz_52;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -595,10 +627,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_50;
-  wire       [2:0]    _zz_51;
-  wire                _zz_52;
-  wire                _zz_53;
+  wire       [2:0]    _zz_53;
+  wire       [2:0]    _zz_54;
+  wire                _zz_55;
+  wire                _zz_56;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -635,16 +667,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_54;
-  wire                _zz_55;
-  wire                _zz_56;
-  wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_57;
   wire                _zz_58;
-  reg                 _zz_59;
+  wire                _zz_59;
+  wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_60;
-  reg                 _zz_61;
-  reg        [31:0]   _zz_62;
+  wire                _zz_61;
+  reg                 _zz_62;
+  wire                _zz_63;
+  reg                 _zz_64;
+  reg        [31:0]   _zz_65;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -664,7 +696,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_63;
+  wire       [31:0]   _zz_66;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -681,31 +713,29 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_64;
+  wire                _zz_67;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_65;
-  reg        [3:0]    _zz_66;
+  reg        [31:0]   _zz_68;
+  reg        [3:0]    _zz_69;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_67;
-  reg        [31:0]   _zz_68;
-  wire                _zz_69;
-  reg        [31:0]   _zz_70;
-  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [29:0]   _zz_71;
+  wire                _zz_70;
+  reg        [31:0]   _zz_71;
   wire                _zz_72;
-  wire                _zz_73;
-  wire                _zz_74;
+  reg        [31:0]   _zz_73;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
+  wire       [27:0]   _zz_74;
   wire                _zz_75;
   wire                _zz_76;
   wire                _zz_77;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_78;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_79;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_80;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_81;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_82;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_83;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_84;
+  wire                _zz_78;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_79;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_80;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_81;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_82;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_83;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_84;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_85;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -713,40 +743,37 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_85;
+  reg                 _zz_86;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_86;
   reg        [31:0]   _zz_87;
-  wire                _zz_88;
-  reg        [19:0]   _zz_89;
-  wire                _zz_90;
-  reg        [19:0]   _zz_91;
-  reg        [31:0]   _zz_92;
+  reg        [31:0]   _zz_88;
+  wire                _zz_89;
+  reg        [19:0]   _zz_90;
+  wire                _zz_91;
+  reg        [19:0]   _zz_92;
+  reg        [31:0]   _zz_93;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
-  reg                 execute_LightShifterPlugin_isActive;
-  wire                execute_LightShifterPlugin_isShift;
-  reg        [4:0]    execute_LightShifterPlugin_amplitudeReg;
-  wire       [4:0]    execute_LightShifterPlugin_amplitude;
-  wire       [31:0]   execute_LightShifterPlugin_shiftInput;
-  wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
+  wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
+  reg        [31:0]   _zz_94;
+  wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
+  reg        [31:0]   _zz_95;
   reg                 _zz_96;
-  reg        [4:0]    _zz_97;
+  reg                 _zz_97;
+  reg                 _zz_98;
+  reg        [4:0]    _zz_99;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_98;
-  reg                 _zz_99;
-  reg                 _zz_100;
+  wire       [2:0]    _zz_100;
+  reg                 _zz_101;
+  reg                 _zz_102;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_101;
-  reg        [10:0]   _zz_102;
   wire                _zz_103;
-  reg        [19:0]   _zz_104;
+  reg        [10:0]   _zz_104;
   wire                _zz_105;
-  reg        [18:0]   _zz_106;
-  reg        [31:0]   _zz_107;
+  reg        [19:0]   _zz_106;
+  wire                _zz_107;
+  reg        [18:0]   _zz_108;
+  reg        [31:0]   _zz_109;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -768,9 +795,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_108;
-  wire                _zz_109;
   wire                _zz_110;
+  wire                _zz_111;
+  wire                _zz_112;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -811,22 +838,20 @@ module VexRiscv (
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
   reg        [31:0]   execute_CsrPlugin_writeData;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
-  reg        [32:0]   memory_MulDivIterativePlugin_rs1;
-  reg        [31:0]   memory_MulDivIterativePlugin_rs2;
-  reg        [64:0]   memory_MulDivIterativePlugin_accumulator;
-  wire                memory_MulDivIterativePlugin_frontendOk;
-  reg                 memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  reg                 memory_MulDivIterativePlugin_mul_counter_willClear;
-  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_valueNext;
-  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
-  wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
-  wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
-  wire                _zz_111;
-  wire                _zz_112;
-  reg        [32:0]   _zz_113;
+  reg                 execute_MulPlugin_aSigned;
+  reg                 execute_MulPlugin_bSigned;
+  wire       [31:0]   execute_MulPlugin_a;
+  wire       [31:0]   execute_MulPlugin_b;
+  wire       [15:0]   execute_MulPlugin_aULow;
+  wire       [15:0]   execute_MulPlugin_bULow;
+  wire       [16:0]   execute_MulPlugin_aSLow;
+  wire       [16:0]   execute_MulPlugin_bSLow;
+  wire       [16:0]   execute_MulPlugin_aHigh;
+  wire       [16:0]   execute_MulPlugin_bHigh;
+  wire       [65:0]   writeBack_MulPlugin_result;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_114;
-  wire       [31:0]   _zz_115;
+  reg        [31:0]   _zz_113;
+  wire       [31:0]   _zz_114;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
@@ -855,6 +880,7 @@ module VexRiscv (
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
@@ -862,8 +888,7 @@ module VexRiscv (
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
   reg                 decode_to_execute_IS_MUL;
   reg                 execute_to_memory_IS_MUL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
@@ -883,9 +908,16 @@ module VexRiscv (
   reg                 execute_to_memory_MMU_RSP2_bypassTranslation;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   reg                 execute_to_memory_BRANCH_DO;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -897,6 +929,7 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_2944;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_115;
   reg        [31:0]   _zz_116;
   reg        [31:0]   _zz_117;
   reg        [31:0]   _zz_118;
@@ -906,9 +939,8 @@ module VexRiscv (
   reg        [31:0]   _zz_122;
   reg        [31:0]   _zz_123;
   reg        [31:0]   _zz_124;
-  reg        [31:0]   _zz_125;
-  reg        [2:0]    _zz_126;
-  reg                 _zz_127;
+  reg        [2:0]    _zz_125;
+  reg                 _zz_126;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -922,7 +954,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_128;
+  reg        [3:0]    _zz_127;
   `ifndef SYNTHESIS
   reg [39:0] _zz_1_string;
   reg [39:0] _zz_2_string;
@@ -936,63 +968,68 @@ module VexRiscv (
   reg [31:0] _zz_8_string;
   reg [31:0] _zz_9_string;
   reg [31:0] _zz_10_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
   reg [71:0] _zz_11_string;
   reg [71:0] _zz_12_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
   reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [71:0] _zz_15_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
   reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_18_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_17_string;
-  reg [63:0] _zz_18_string;
   reg [63:0] _zz_19_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_20_string;
-  reg [23:0] _zz_21_string;
   reg [23:0] _zz_22_string;
+  reg [23:0] _zz_23_string;
+  reg [23:0] _zz_24_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_23_string;
-  reg [95:0] _zz_24_string;
   reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_27_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
-  reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
-  reg [39:0] writeBack_ENV_CTRL_string;
   reg [39:0] _zz_29_string;
+  reg [39:0] execute_ENV_CTRL_string;
+  reg [39:0] _zz_30_string;
+  reg [39:0] writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_31_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
+  reg [31:0] _zz_32_string;
+  reg [71:0] memory_SHIFT_CTRL_string;
+  reg [71:0] _zz_34_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_32_string;
+  reg [71:0] _zz_35_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_34_string;
+  reg [23:0] _zz_37_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_35_string;
+  reg [95:0] _zz_38_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_36_string;
+  reg [63:0] _zz_39_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_37_string;
-  reg [39:0] _zz_41_string;
-  reg [31:0] _zz_42_string;
-  reg [71:0] _zz_43_string;
+  reg [39:0] _zz_40_string;
   reg [39:0] _zz_44_string;
-  reg [63:0] _zz_45_string;
-  reg [23:0] _zz_46_string;
-  reg [95:0] _zz_47_string;
-  reg [95:0] _zz_78_string;
-  reg [23:0] _zz_79_string;
-  reg [63:0] _zz_80_string;
-  reg [39:0] _zz_81_string;
-  reg [71:0] _zz_82_string;
-  reg [31:0] _zz_83_string;
-  reg [39:0] _zz_84_string;
+  reg [31:0] _zz_45_string;
+  reg [71:0] _zz_46_string;
+  reg [39:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [23:0] _zz_49_string;
+  reg [95:0] _zz_50_string;
+  reg [95:0] _zz_79_string;
+  reg [23:0] _zz_80_string;
+  reg [63:0] _zz_81_string;
+  reg [39:0] _zz_82_string;
+  reg [71:0] _zz_83_string;
+  reg [31:0] _zz_84_string;
+  reg [39:0] _zz_85_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1001,253 +1038,271 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_141 = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_142 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_143 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_144 = ((_zz_134 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_145 = ((_zz_134 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_146 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_147 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_148 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_149 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_150 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_151 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_152 = (1'b1 || (! 1'b1));
-  assign _zz_153 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_154 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_155 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_156 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_157 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_158 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_159 = (iBus_cmd_valid || (_zz_126 != 3'b000));
-  assign _zz_160 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_161 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_162 = ((_zz_108 && 1'b1) && (! 1'b0));
-  assign _zz_163 = ((_zz_109 && 1'b1) && (! 1'b0));
-  assign _zz_164 = ((_zz_110 && 1'b1) && (! 1'b0));
-  assign _zz_165 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_166 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_167 = execute_INSTRUCTION[13];
-  assign _zz_168 = _zz_71[29 : 29];
-  assign _zz_169 = _zz_71[28 : 28];
-  assign _zz_170 = _zz_71[27 : 27];
-  assign _zz_171 = _zz_71[24 : 24];
-  assign _zz_172 = _zz_71[15 : 15];
-  assign _zz_173 = _zz_71[11 : 11];
-  assign _zz_174 = _zz_71[10 : 10];
-  assign _zz_175 = _zz_71[9 : 9];
-  assign _zz_176 = _zz_71[12 : 12];
-  assign _zz_177 = _zz_71[5 : 5];
-  assign _zz_178 = _zz_71[3 : 3];
-  assign _zz_179 = _zz_71[18 : 18];
-  assign _zz_180 = _zz_71[8 : 8];
-  assign _zz_181 = _zz_71[4 : 4];
-  assign _zz_182 = _zz_71[0 : 0];
-  assign _zz_183 = (_zz_50 - 3'b001);
-  assign _zz_184 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_185 = {29'd0, _zz_184};
-  assign _zz_186 = execute_SRC_LESS;
-  assign _zz_187 = 3'b100;
-  assign _zz_188 = execute_INSTRUCTION[19 : 15];
-  assign _zz_189 = execute_INSTRUCTION[31 : 20];
-  assign _zz_190 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_191 = ($signed(_zz_192) + $signed(_zz_195));
-  assign _zz_192 = ($signed(_zz_193) + $signed(_zz_194));
-  assign _zz_193 = execute_SRC1;
-  assign _zz_194 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_195 = (execute_SRC_USE_SUB_LESS ? _zz_196 : _zz_197);
-  assign _zz_196 = 32'h00000001;
-  assign _zz_197 = 32'h0;
-  assign _zz_198 = (_zz_199 >>> 1);
-  assign _zz_199 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_200 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_201 = execute_INSTRUCTION[31 : 20];
-  assign _zz_202 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_203 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_204 = {5'd0, _zz_203};
-  assign _zz_205 = (_zz_207 + _zz_209);
-  assign _zz_206 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_207 = {{1{_zz_206[32]}}, _zz_206};
-  assign _zz_208 = _zz_210;
-  assign _zz_209 = {{1{_zz_208[32]}}, _zz_208};
-  assign _zz_210 = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_211 = _zz_112;
-  assign _zz_212 = {32'd0, _zz_211};
-  assign _zz_213 = _zz_111;
-  assign _zz_214 = {31'd0, _zz_213};
-  assign _zz_215 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_216 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_140 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_141 = ((_zz_133 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_142 = ((_zz_133 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_143 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_144 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_145 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_146 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign _zz_147 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_148 = (1'b1 || (! 1'b1));
+  assign _zz_149 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_150 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_151 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_152 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_153 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_154 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_155 = execute_INSTRUCTION[13 : 12];
+  assign _zz_156 = (iBus_cmd_valid || (_zz_125 != 3'b000));
+  assign _zz_157 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_158 = ((_zz_110 && 1'b1) && (! 1'b0));
+  assign _zz_159 = ((_zz_111 && 1'b1) && (! 1'b0));
+  assign _zz_160 = ((_zz_112 && 1'b1) && (! 1'b0));
+  assign _zz_161 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_162 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_163 = execute_INSTRUCTION[13];
+  assign _zz_164 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_165 = ($signed(_zz_166) + $signed(_zz_171));
+  assign _zz_166 = ($signed(_zz_167) + $signed(_zz_169));
+  assign _zz_167 = 52'h0;
+  assign _zz_168 = {1'b0,memory_MUL_LL};
+  assign _zz_169 = {{19{_zz_168[32]}}, _zz_168};
+  assign _zz_170 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_171 = {{2{_zz_170[49]}}, _zz_170};
+  assign _zz_172 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_173 = {{2{_zz_172[49]}}, _zz_172};
+  assign _zz_174 = ($signed(_zz_176) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_175 = _zz_174[31 : 0];
+  assign _zz_176 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_177 = _zz_74[27 : 27];
+  assign _zz_178 = _zz_74[24 : 24];
+  assign _zz_179 = _zz_74[15 : 15];
+  assign _zz_180 = _zz_74[11 : 11];
+  assign _zz_181 = _zz_74[10 : 10];
+  assign _zz_182 = _zz_74[9 : 9];
+  assign _zz_183 = _zz_74[12 : 12];
+  assign _zz_184 = _zz_74[5 : 5];
+  assign _zz_185 = _zz_74[3 : 3];
+  assign _zz_186 = _zz_74[18 : 18];
+  assign _zz_187 = _zz_74[8 : 8];
+  assign _zz_188 = _zz_74[4 : 4];
+  assign _zz_189 = _zz_74[0 : 0];
+  assign _zz_190 = (_zz_53 - 3'b001);
+  assign _zz_191 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_192 = {29'd0, _zz_191};
+  assign _zz_193 = execute_SRC_LESS;
+  assign _zz_194 = 3'b100;
+  assign _zz_195 = execute_INSTRUCTION[19 : 15];
+  assign _zz_196 = execute_INSTRUCTION[31 : 20];
+  assign _zz_197 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_198 = ($signed(_zz_199) + $signed(_zz_202));
+  assign _zz_199 = ($signed(_zz_200) + $signed(_zz_201));
+  assign _zz_200 = execute_SRC1;
+  assign _zz_201 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_202 = (execute_SRC_USE_SUB_LESS ? _zz_203 : _zz_204);
+  assign _zz_203 = 32'h00000001;
+  assign _zz_204 = 32'h0;
+  assign _zz_205 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_206 = execute_INSTRUCTION[31 : 20];
+  assign _zz_207 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_208 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_209 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_210 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_211 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_212 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_213 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_214 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_215 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_216 = execute_CsrPlugin_writeData[7 : 7];
   assign _zz_217 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_218 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_219 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_220 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_221 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_222 = 1'b1;
-  assign _zz_223 = 1'b1;
-  assign _zz_224 = {_zz_53,_zz_52};
-  assign _zz_225 = 32'h0000107f;
-  assign _zz_226 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_227 = 32'h00002073;
-  assign _zz_228 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_229 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_230 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_231) == 32'h00000003),{(_zz_232 == _zz_233),{_zz_234,{_zz_235,_zz_236}}}}}};
-  assign _zz_231 = 32'h0000505f;
-  assign _zz_232 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_233 = 32'h00000063;
-  assign _zz_234 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_235 = ((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033);
-  assign _zz_236 = {((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_237) == 32'h00001013),{(_zz_238 == _zz_239),{_zz_240,{_zz_241,_zz_242}}}}}};
-  assign _zz_237 = 32'hfc00705f;
-  assign _zz_238 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_239 = 32'h00005033;
-  assign _zz_240 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_241 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_242 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_243 = ((decode_INSTRUCTION & 32'h02000074) == 32'h02000030);
-  assign _zz_244 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
-  assign _zz_245 = 1'b0;
-  assign _zz_246 = (((decode_INSTRUCTION & _zz_249) == 32'h10000050) != 1'b0);
-  assign _zz_247 = ({_zz_250,_zz_251} != 2'b00);
-  assign _zz_248 = {({_zz_252,_zz_253} != 2'b00),{(_zz_254 != _zz_255),{_zz_256,{_zz_257,_zz_258}}}};
-  assign _zz_249 = 32'h10403050;
-  assign _zz_250 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_251 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_252 = _zz_75;
-  assign _zz_253 = ((decode_INSTRUCTION & _zz_259) == 32'h00000004);
-  assign _zz_254 = ((decode_INSTRUCTION & _zz_260) == 32'h00000040);
-  assign _zz_255 = 1'b0;
-  assign _zz_256 = ({_zz_261,_zz_262} != 2'b00);
-  assign _zz_257 = (_zz_263 != 1'b0);
-  assign _zz_258 = {(_zz_264 != _zz_265),{_zz_266,{_zz_267,_zz_268}}};
-  assign _zz_259 = 32'h0000001c;
-  assign _zz_260 = 32'h00000058;
-  assign _zz_261 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_262 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz_263 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
-  assign _zz_264 = {(_zz_269 == _zz_270),{_zz_271,_zz_272}};
-  assign _zz_265 = 3'b000;
-  assign _zz_266 = ({_zz_273,{_zz_274,_zz_275}} != 3'b000);
-  assign _zz_267 = (_zz_276 != 1'b0);
-  assign _zz_268 = {(_zz_277 != _zz_278),{_zz_279,{_zz_280,_zz_281}}};
-  assign _zz_269 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_270 = 32'h40001010;
-  assign _zz_271 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz_272 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz_273 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_274 = ((decode_INSTRUCTION & _zz_282) == 32'h00001010);
-  assign _zz_275 = ((decode_INSTRUCTION & _zz_283) == 32'h00001010);
-  assign _zz_276 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_277 = _zz_76;
-  assign _zz_278 = 1'b0;
-  assign _zz_279 = ({_zz_284,_zz_285} != 2'b00);
-  assign _zz_280 = ({_zz_286,_zz_287} != 2'b00);
-  assign _zz_281 = {(_zz_288 != _zz_289),{_zz_290,{_zz_291,_zz_292}}};
-  assign _zz_282 = 32'h00003034;
-  assign _zz_283 = 32'h02003054;
-  assign _zz_284 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_285 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_286 = ((decode_INSTRUCTION & _zz_293) == 32'h00006000);
-  assign _zz_287 = ((decode_INSTRUCTION & _zz_294) == 32'h00004000);
-  assign _zz_288 = _zz_73;
-  assign _zz_289 = 1'b0;
-  assign _zz_290 = ({_zz_295,_zz_296} != 2'b00);
-  assign _zz_291 = (_zz_297 != 1'b0);
-  assign _zz_292 = {(_zz_298 != _zz_299),{_zz_300,{_zz_301,_zz_302}}};
-  assign _zz_293 = 32'h00006004;
-  assign _zz_294 = 32'h00005004;
-  assign _zz_295 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_296 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_297 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_298 = ((decode_INSTRUCTION & _zz_303) == 32'h00000010);
-  assign _zz_299 = 1'b0;
-  assign _zz_300 = ({_zz_74,{_zz_304,_zz_305}} != 3'b000);
-  assign _zz_301 = ({_zz_306,_zz_307} != 6'h0);
-  assign _zz_302 = {(_zz_308 != _zz_309),{_zz_310,{_zz_311,_zz_312}}};
-  assign _zz_303 = 32'h00000010;
-  assign _zz_304 = ((decode_INSTRUCTION & _zz_313) == 32'h00000010);
-  assign _zz_305 = ((decode_INSTRUCTION & _zz_314) == 32'h00000020);
-  assign _zz_306 = _zz_75;
-  assign _zz_307 = {(_zz_315 == _zz_316),{_zz_317,{_zz_318,_zz_319}}};
-  assign _zz_308 = {_zz_74,(_zz_320 == _zz_321)};
-  assign _zz_309 = 2'b00;
-  assign _zz_310 = ({_zz_74,_zz_322} != 2'b00);
-  assign _zz_311 = ({_zz_323,_zz_324} != 4'b0000);
-  assign _zz_312 = {(_zz_325 != _zz_326),{_zz_327,{_zz_328,_zz_329}}};
-  assign _zz_313 = 32'h00000030;
-  assign _zz_314 = 32'h02000060;
-  assign _zz_315 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_316 = 32'h00001010;
-  assign _zz_317 = ((decode_INSTRUCTION & _zz_330) == 32'h00002010);
-  assign _zz_318 = (_zz_331 == _zz_332);
-  assign _zz_319 = {_zz_333,_zz_334};
-  assign _zz_320 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_321 = 32'h00000020;
-  assign _zz_322 = ((decode_INSTRUCTION & _zz_335) == 32'h0);
-  assign _zz_323 = (_zz_336 == _zz_337);
-  assign _zz_324 = {_zz_338,{_zz_339,_zz_340}};
-  assign _zz_325 = (_zz_341 == _zz_342);
-  assign _zz_326 = 1'b0;
-  assign _zz_327 = ({_zz_343,_zz_344} != 3'b000);
-  assign _zz_328 = (_zz_345 != _zz_346);
-  assign _zz_329 = {_zz_347,_zz_348};
-  assign _zz_330 = 32'h00002010;
-  assign _zz_331 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_332 = 32'h00000010;
-  assign _zz_333 = ((decode_INSTRUCTION & _zz_349) == 32'h00000004);
-  assign _zz_334 = ((decode_INSTRUCTION & _zz_350) == 32'h0);
+  assign _zz_218 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_219 = 1'b1;
+  assign _zz_220 = 1'b1;
+  assign _zz_221 = {_zz_56,_zz_55};
+  assign _zz_222 = 32'h0000107f;
+  assign _zz_223 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_224 = 32'h00002073;
+  assign _zz_225 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_226 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_227 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_228) == 32'h00000003),{(_zz_229 == _zz_230),{_zz_231,{_zz_232,_zz_233}}}}}};
+  assign _zz_228 = 32'h0000505f;
+  assign _zz_229 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_230 = 32'h00000063;
+  assign _zz_231 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_232 = ((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033);
+  assign _zz_233 = {((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_234) == 32'h00001013),{(_zz_235 == _zz_236),{_zz_237,{_zz_238,_zz_239}}}}}};
+  assign _zz_234 = 32'hfc00307f;
+  assign _zz_235 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_236 = 32'h00005033;
+  assign _zz_237 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_238 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_239 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_240 = 32'h02000074;
+  assign _zz_241 = (decode_INSTRUCTION & 32'h10003050);
+  assign _zz_242 = 32'h00000050;
+  assign _zz_243 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz_244 = {(_zz_249 == _zz_250),(_zz_251 == _zz_252)};
+  assign _zz_245 = 2'b00;
+  assign _zz_246 = ({_zz_78,_zz_253} != 2'b00);
+  assign _zz_247 = (_zz_254 != 1'b0);
+  assign _zz_248 = {(_zz_255 != _zz_256),{_zz_257,{_zz_258,_zz_259}}};
+  assign _zz_249 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_250 = 32'h00001050;
+  assign _zz_251 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_252 = 32'h00002050;
+  assign _zz_253 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_254 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_255 = {(_zz_260 == _zz_261),(_zz_262 == _zz_263)};
+  assign _zz_256 = 2'b00;
+  assign _zz_257 = ((_zz_264 == _zz_265) != 1'b0);
+  assign _zz_258 = ({_zz_266,_zz_267} != 3'b000);
+  assign _zz_259 = {(_zz_268 != _zz_269),{_zz_270,{_zz_271,_zz_272}}};
+  assign _zz_260 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_261 = 32'h00000040;
+  assign _zz_262 = (decode_INSTRUCTION & 32'h00403040);
+  assign _zz_263 = 32'h00000040;
+  assign _zz_264 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz_265 = 32'h00005010;
+  assign _zz_266 = ((decode_INSTRUCTION & _zz_273) == 32'h40001010);
+  assign _zz_267 = {(_zz_274 == _zz_275),(_zz_276 == _zz_277)};
+  assign _zz_268 = ((decode_INSTRUCTION & _zz_278) == 32'h00000024);
+  assign _zz_269 = 1'b0;
+  assign _zz_270 = ((_zz_279 == _zz_280) != 1'b0);
+  assign _zz_271 = (_zz_281 != 1'b0);
+  assign _zz_272 = {(_zz_282 != _zz_283),{_zz_284,{_zz_285,_zz_286}}};
+  assign _zz_273 = 32'h40003054;
+  assign _zz_274 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_275 = 32'h00001010;
+  assign _zz_276 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_277 = 32'h00001010;
+  assign _zz_278 = 32'h00000064;
+  assign _zz_279 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_280 = 32'h00001000;
+  assign _zz_281 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_282 = {(_zz_287 == _zz_288),(_zz_289 == _zz_290)};
+  assign _zz_283 = 2'b00;
+  assign _zz_284 = ((_zz_291 == _zz_292) != 1'b0);
+  assign _zz_285 = (_zz_76 != 1'b0);
+  assign _zz_286 = {(_zz_293 != _zz_294),{_zz_295,{_zz_296,_zz_297}}};
+  assign _zz_287 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_288 = 32'h00002000;
+  assign _zz_289 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_290 = 32'h00001000;
+  assign _zz_291 = (decode_INSTRUCTION & 32'h00004004);
+  assign _zz_292 = 32'h00004000;
+  assign _zz_293 = {((decode_INSTRUCTION & _zz_298) == 32'h00000020),((decode_INSTRUCTION & _zz_299) == 32'h00000020)};
+  assign _zz_294 = 2'b00;
+  assign _zz_295 = (((decode_INSTRUCTION & _zz_300) == 32'h00000020) != 1'b0);
+  assign _zz_296 = ({_zz_301,{_zz_302,_zz_303}} != 4'b0000);
+  assign _zz_297 = {({_zz_304,_zz_305} != 5'h0),{(_zz_306 != _zz_307),{_zz_308,{_zz_309,_zz_310}}}};
+  assign _zz_298 = 32'h00000034;
+  assign _zz_299 = 32'h00000064;
+  assign _zz_300 = 32'h00000020;
+  assign _zz_301 = ((decode_INSTRUCTION & 32'h00000040) == 32'h00000040);
+  assign _zz_302 = _zz_77;
+  assign _zz_303 = {(_zz_311 == _zz_312),(_zz_313 == _zz_314)};
+  assign _zz_304 = _zz_77;
+  assign _zz_305 = {(_zz_315 == _zz_316),{_zz_317,{_zz_318,_zz_319}}};
+  assign _zz_306 = {_zz_78,{_zz_320,{_zz_321,_zz_322}}};
+  assign _zz_307 = 6'h0;
+  assign _zz_308 = ({_zz_77,_zz_323} != 2'b00);
+  assign _zz_309 = ({_zz_324,_zz_325} != 2'b00);
+  assign _zz_310 = {(_zz_326 != _zz_327),{_zz_328,{_zz_329,_zz_330}}};
+  assign _zz_311 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_312 = 32'h00000010;
+  assign _zz_313 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz_314 = 32'h00000020;
+  assign _zz_315 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_316 = 32'h00002010;
+  assign _zz_317 = ((decode_INSTRUCTION & _zz_331) == 32'h00000010);
+  assign _zz_318 = (_zz_332 == _zz_333);
+  assign _zz_319 = (_zz_334 == _zz_335);
+  assign _zz_320 = ((decode_INSTRUCTION & _zz_336) == 32'h00001010);
+  assign _zz_321 = (_zz_337 == _zz_338);
+  assign _zz_322 = {_zz_339,{_zz_340,_zz_341}};
+  assign _zz_323 = ((decode_INSTRUCTION & _zz_342) == 32'h00000020);
+  assign _zz_324 = _zz_77;
+  assign _zz_325 = (_zz_343 == _zz_344);
+  assign _zz_326 = {_zz_345,{_zz_346,_zz_347}};
+  assign _zz_327 = 4'b0000;
+  assign _zz_328 = (_zz_348 != 1'b0);
+  assign _zz_329 = (_zz_349 != _zz_350);
+  assign _zz_330 = {_zz_351,{_zz_352,_zz_353}};
+  assign _zz_331 = 32'h00001030;
+  assign _zz_332 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz_333 = 32'h00002020;
+  assign _zz_334 = (decode_INSTRUCTION & 32'h02003020);
   assign _zz_335 = 32'h00000020;
-  assign _zz_336 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_337 = 32'h0;
-  assign _zz_338 = ((decode_INSTRUCTION & _zz_351) == 32'h0);
-  assign _zz_339 = _zz_73;
-  assign _zz_340 = (_zz_352 == _zz_353);
-  assign _zz_341 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_342 = 32'h0;
-  assign _zz_343 = (_zz_354 == _zz_355);
-  assign _zz_344 = {_zz_356,_zz_357};
-  assign _zz_345 = {_zz_358,_zz_72};
-  assign _zz_346 = 2'b00;
-  assign _zz_347 = ({_zz_359,_zz_360} != 2'b00);
-  assign _zz_348 = (_zz_361 != 1'b0);
-  assign _zz_349 = 32'h0000000c;
-  assign _zz_350 = 32'h00000028;
-  assign _zz_351 = 32'h00000018;
-  assign _zz_352 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_353 = 32'h00001000;
-  assign _zz_354 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_355 = 32'h00000040;
-  assign _zz_356 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_357 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz_358 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_359 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_360 = _zz_72;
-  assign _zz_361 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
+  assign _zz_336 = 32'h00001010;
+  assign _zz_337 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_338 = 32'h00002010;
+  assign _zz_339 = ((decode_INSTRUCTION & _zz_354) == 32'h00000010);
+  assign _zz_340 = (_zz_355 == _zz_356);
+  assign _zz_341 = (_zz_357 == _zz_358);
+  assign _zz_342 = 32'h00000070;
+  assign _zz_343 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_344 = 32'h0;
+  assign _zz_345 = ((decode_INSTRUCTION & _zz_359) == 32'h0);
+  assign _zz_346 = (_zz_360 == _zz_361);
+  assign _zz_347 = {_zz_76,_zz_362};
+  assign _zz_348 = ((decode_INSTRUCTION & _zz_363) == 32'h0);
+  assign _zz_349 = {_zz_364,{_zz_365,_zz_366}};
+  assign _zz_350 = 3'b000;
+  assign _zz_351 = ({_zz_367,_zz_368} != 2'b00);
+  assign _zz_352 = (_zz_369 != _zz_370);
+  assign _zz_353 = (_zz_371 != _zz_372);
+  assign _zz_354 = 32'h00000050;
+  assign _zz_355 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_356 = 32'h00000004;
+  assign _zz_357 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_358 = 32'h0;
+  assign _zz_359 = 32'h00000044;
+  assign _zz_360 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_361 = 32'h0;
+  assign _zz_362 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_363 = 32'h00000058;
+  assign _zz_364 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_365 = ((decode_INSTRUCTION & _zz_373) == 32'h00002010);
+  assign _zz_366 = ((decode_INSTRUCTION & _zz_374) == 32'h40000030);
+  assign _zz_367 = ((decode_INSTRUCTION & _zz_375) == 32'h00000004);
+  assign _zz_368 = _zz_75;
+  assign _zz_369 = {(_zz_376 == _zz_377),_zz_75};
+  assign _zz_370 = 2'b00;
+  assign _zz_371 = ((decode_INSTRUCTION & _zz_378) == 32'h00001008);
+  assign _zz_372 = 1'b0;
+  assign _zz_373 = 32'h00002014;
+  assign _zz_374 = 32'h40000034;
+  assign _zz_375 = 32'h00000014;
+  assign _zz_376 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_377 = 32'h00000004;
+  assign _zz_378 = 32'h00001048;
   always @ (posedge clk) begin
-    if(_zz_222) begin
-      _zz_138 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_219) begin
+      _zz_137 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_223) begin
-      _zz_139 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_220) begin
+      _zz_138 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_40) begin
+    if(_zz_43) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_129                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_130                                                     ), //i
+    .io_flush                                 (_zz_128                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_129                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_131                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_132                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_133                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_130                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_131                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_132                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1260,8 +1315,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_134                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_135                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_133                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_134                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1269,8 +1324,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_136                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_137                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_135                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_136                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1283,15 +1338,15 @@ module VexRiscv (
     .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_224)
+    case(_zz_221)
       2'b00 : begin
-        _zz_140 = CsrPlugin_jumpInterface_payload;
+        _zz_139 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_140 = DBusSimplePlugin_redoBranch_payload;
+        _zz_139 = DBusSimplePlugin_redoBranch_payload;
       end
       default : begin
-        _zz_140 = BranchPlugin_jumpInterface_payload;
+        _zz_139 = BranchPlugin_jumpInterface_payload;
       end
     endcase
   end
@@ -1398,15 +1453,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_11)
       `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
@@ -1425,12 +1471,39 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_13)
       `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
       default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
+      default : _zz_15_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1442,27 +1515,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_16)
       `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
       `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
       default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
+      default : _zz_18_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1474,27 +1547,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_17_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_17_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_17_string = "BITWISE ";
-      default : _zz_17_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_18_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_18_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_18_string = "BITWISE ";
-      default : _zz_18_string = "????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_19)
       `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
       default : _zz_19_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1507,30 +1580,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
-      default : _zz_21_string = "???";
-    endcase
-  end
-  always @(*) begin
     case(_zz_22)
       `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
       `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
       `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
       default : _zz_22_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
+      default : _zz_23_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_24_string = "PC ";
+      default : _zz_24_string = "???";
     endcase
   end
   always @(*) begin
@@ -1543,30 +1616,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
-      default : _zz_23_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_25)
       `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
       `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
       `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
       default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_27)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
+      default : _zz_27_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1578,11 +1651,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1594,11 +1667,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_30)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_30_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_30_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_30_string = "ECALL";
+      default : _zz_30_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1610,11 +1683,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_31)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_31_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_31_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_31_string = "ECALL";
+      default : _zz_31_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1627,12 +1700,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_32)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_32_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_32_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_32_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_32_string = "JALR";
+      default : _zz_32_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1645,12 +1736,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_32)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_32_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_32_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_32_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_32_string = "SRA_1    ";
-      default : _zz_32_string = "?????????";
+    case(_zz_35)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_35_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_35_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_35_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_35_string = "SRA_1    ";
+      default : _zz_35_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1663,12 +1754,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_34_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_34_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_34_string = "PC ";
-      default : _zz_34_string = "???";
+    case(_zz_37)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_37_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_37_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_37_string = "PC ";
+      default : _zz_37_string = "???";
     endcase
   end
   always @(*) begin
@@ -1681,12 +1772,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_35_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_35_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_35_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_35_string = "URS1        ";
-      default : _zz_35_string = "????????????";
+    case(_zz_38)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_38_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_38_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_38_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_38_string = "URS1        ";
+      default : _zz_38_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1698,11 +1789,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_36_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_36_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_36_string = "BITWISE ";
-      default : _zz_36_string = "????????";
+    case(_zz_39)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_39_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_39_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_39_string = "BITWISE ";
+      default : _zz_39_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1714,131 +1805,131 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_37_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_37_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_37_string = "AND_1";
-      default : _zz_37_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_41)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_41_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_41_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_41_string = "ECALL";
-      default : _zz_41_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_42)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_42_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_42_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_42_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_42_string = "JALR";
-      default : _zz_42_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_43)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_43_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_43_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_43_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_43_string = "SRA_1    ";
-      default : _zz_43_string = "?????????";
+    case(_zz_40)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_40_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_40_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_40_string = "AND_1";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_44)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_44_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_44_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_44_string = "AND_1";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44_string = "ECALL";
       default : _zz_44_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_45)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
-      default : _zz_45_string = "????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_45_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_45_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_45_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_45_string = "JALR";
+      default : _zz_45_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_46)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_46_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_46_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_46_string = "PC ";
-      default : _zz_46_string = "???";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46_string = "SRA_1    ";
+      default : _zz_46_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_47)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_47_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_47_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_47_string = "URS1        ";
-      default : _zz_47_string = "????????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_47_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_47_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_47_string = "AND_1";
+      default : _zz_47_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_78)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_78_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_78_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_78_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_78_string = "URS1        ";
-      default : _zz_78_string = "????????????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_49)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_49_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_49_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_49_string = "PC ";
+      default : _zz_49_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_50)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_50_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_50_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_50_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_50_string = "URS1        ";
+      default : _zz_50_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_79)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_79_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_79_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_79_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_79_string = "PC ";
-      default : _zz_79_string = "???";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_79_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_79_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_79_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_79_string = "URS1        ";
+      default : _zz_79_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_80)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_80_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_80_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_80_string = "BITWISE ";
-      default : _zz_80_string = "????????";
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_80_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_80_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_80_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_80_string = "PC ";
+      default : _zz_80_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_81)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_81_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_81_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_81_string = "AND_1";
-      default : _zz_81_string = "?????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_81_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_81_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_81_string = "BITWISE ";
+      default : _zz_81_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_82)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_82_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_82_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_82_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_82_string = "SRA_1    ";
-      default : _zz_82_string = "?????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_82_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_82_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_82_string = "AND_1";
+      default : _zz_82_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_83)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_83_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_83_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_83_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_83_string = "JALR";
-      default : _zz_83_string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_83_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_83_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_83_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_83_string = "SRA_1    ";
+      default : _zz_83_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_84)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_84_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_84_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_84_string = "ECALL";
-      default : _zz_84_string = "?????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_84_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_84_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_84_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_84_string = "JALR";
+      default : _zz_84_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_85)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_85_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_85_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_85_string = "ECALL";
+      default : _zz_85_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1885,6 +1976,15 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
       `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
@@ -1919,11 +2019,18 @@ module VexRiscv (
   end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_165) + $signed(_zz_173));
   assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_100;
+  assign execute_BRANCH_DO = _zz_102;
+  assign execute_SHIFT_RIGHT = _zz_175;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_86;
+  assign execute_REGFILE_WRITE_DATA = _zz_87;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
@@ -1931,113 +2038,134 @@ module VexRiscv (
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign decode_IS_RS2_SIGNED = _zz_168[0];
-  assign decode_IS_RS1_SIGNED = _zz_169[0];
-  assign decode_IS_MUL = _zz_170[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_177[0];
   assign _zz_1 = _zz_2;
   assign _zz_3 = _zz_4;
   assign decode_ENV_CTRL = _zz_5;
   assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_171[0];
+  assign decode_IS_CSR = _zz_178[0];
   assign decode_BRANCH_CTRL = _zz_8;
   assign _zz_9 = _zz_10;
-  assign decode_SHIFT_CTRL = _zz_11;
-  assign _zz_12 = _zz_13;
-  assign decode_ALU_BITWISE_CTRL = _zz_14;
-  assign _zz_15 = _zz_16;
-  assign decode_SRC_LESS_UNSIGNED = _zz_172[0];
-  assign decode_ALU_CTRL = _zz_17;
-  assign _zz_18 = _zz_19;
-  assign decode_MEMORY_STORE = _zz_173[0];
+  assign _zz_11 = _zz_12;
+  assign decode_SHIFT_CTRL = _zz_13;
+  assign _zz_14 = _zz_15;
+  assign decode_ALU_BITWISE_CTRL = _zz_16;
+  assign _zz_17 = _zz_18;
+  assign decode_SRC_LESS_UNSIGNED = _zz_179[0];
+  assign decode_ALU_CTRL = _zz_19;
+  assign _zz_20 = _zz_21;
+  assign decode_MEMORY_STORE = _zz_180[0];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_174[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_175[0];
-  assign decode_SRC2_CTRL = _zz_20;
-  assign _zz_21 = _zz_22;
-  assign decode_SRC1_CTRL = _zz_23;
-  assign _zz_24 = _zz_25;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_181[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_182[0];
+  assign decode_SRC2_CTRL = _zz_22;
+  assign _zz_23 = _zz_24;
+  assign decode_SRC1_CTRL = _zz_25;
+  assign _zz_26 = _zz_27;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
+  assign writeBack_IS_MUL = memory_to_writeBack_IS_MUL;
+  assign writeBack_MUL_HH = memory_to_writeBack_MUL_HH;
+  assign writeBack_MUL_LOW = memory_to_writeBack_MUL_LOW;
+  assign memory_MUL_HL = execute_to_memory_MUL_HL;
+  assign memory_MUL_LH = execute_to_memory_MUL_LH;
+  assign memory_MUL_LL = execute_to_memory_MUL_LL;
   always @ (*) begin
-    _zz_26 = memory_REGFILE_WRITE_DATA;
-    if(_zz_141)begin
-      _zz_26 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    _zz_28 = execute_REGFILE_WRITE_DATA;
+    if(_zz_140)begin
+      _zz_28 = execute_CsrPlugin_readData;
     end
   end
 
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_29;
+  assign execute_ENV_CTRL = _zz_30;
+  assign writeBack_ENV_CTRL = _zz_31;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_176[0];
-  assign decode_RS1_USE = _zz_177[0];
+  assign execute_BRANCH_CTRL = _zz_32;
+  assign decode_RS2_USE = _zz_183[0];
+  assign decode_RS1_USE = _zz_184[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
+  assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_142)begin
-      _zz_31 = _zz_93;
-    end
-    if(_zz_143)begin
-      _zz_31 = execute_CsrPlugin_readData;
+    _zz_33 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid)begin
+      case(memory_SHIFT_CTRL)
+        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
+          _zz_33 = _zz_95;
+        end
+        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
+          _zz_33 = memory_SHIFT_RIGHT;
+        end
+        default : begin
+        end
+      endcase
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_32;
+  assign memory_SHIFT_CTRL = _zz_34;
+  assign execute_SHIFT_CTRL = _zz_35;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_33 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_34;
-  assign execute_SRC1_CTRL = _zz_35;
-  assign decode_SRC_USE_SUB_LESS = _zz_178[0];
-  assign decode_SRC_ADD_ZERO = _zz_179[0];
+  assign _zz_36 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_37;
+  assign execute_SRC1_CTRL = _zz_38;
+  assign decode_SRC_USE_SUB_LESS = _zz_185[0];
+  assign decode_SRC_ADD_ZERO = _zz_186[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_36;
-  assign execute_SRC2 = _zz_92;
-  assign execute_SRC1 = _zz_87;
-  assign execute_ALU_BITWISE_CTRL = _zz_37;
-  assign _zz_38 = writeBack_INSTRUCTION;
-  assign _zz_39 = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_39;
+  assign execute_SRC2 = _zz_93;
+  assign execute_SRC1 = _zz_88;
+  assign execute_ALU_BITWISE_CTRL = _zz_40;
+  assign _zz_41 = writeBack_INSTRUCTION;
+  assign _zz_42 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_40 = 1'b0;
+    _zz_43 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_40 = 1'b1;
+      _zz_43 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_180[0];
+    decode_REGFILE_WRITE_VALID = _zz_187[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_225) == 32'h00001073),{(_zz_226 == _zz_227),{_zz_228,{_zz_229,_zz_230}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_222) == 32'h00001073),{(_zz_223 == _zz_224),{_zz_225,{_zz_226,_zz_227}}}}}}} != 21'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_48 = writeBack_REGFILE_WRITE_DATA;
+    _zz_51 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_48 = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_51 = writeBack_DBusSimplePlugin_rspFormated;
+    end
+    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
+      case(_zz_164)
+        2'b00 : begin
+          _zz_51 = _zz_210;
+        end
+        default : begin
+          _zz_51 = _zz_211;
+        end
+      endcase
     end
   end
 
@@ -2074,30 +2202,30 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = 1'b0;
-  assign decode_MEMORY_ENABLE = _zz_181[0];
-  assign decode_FLUSH_ALL = _zz_182[0];
+  assign decode_MEMORY_ENABLE = _zz_188[0];
+  assign decode_FLUSH_ALL = _zz_189[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_144)begin
+    if(_zz_141)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_145)begin
+    if(_zz_142)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_49 = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_49 = DBusSimplePlugin_redoBranch_payload;
+      _zz_52 = DBusSimplePlugin_redoBranch_payload;
     end
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_49 = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -2113,7 +2241,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_94 || _zz_95)))begin
+    if((decode_arbitration_isValid && (_zz_96 || _zz_97)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
@@ -2144,15 +2272,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_67)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_142)begin
-      if((! execute_LightShifterPlugin_done))begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(_zz_143)begin
+    if(_zz_140)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2182,14 +2305,6 @@ module VexRiscv (
     memory_arbitration_haltItself = 1'b0;
     if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
       memory_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_141)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
-        memory_arbitration_haltItself = 1'b1;
-      end
-      if(_zz_146)begin
-        memory_arbitration_haltItself = 1'b1;
-      end
     end
   end
 
@@ -2236,10 +2351,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_147)begin
+    if(_zz_143)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_148)begin
+    if(_zz_144)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2253,10 +2368,10 @@ module VexRiscv (
     if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_147)begin
+    if(_zz_143)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_148)begin
+    if(_zz_144)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2272,21 +2387,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_147)begin
+    if(_zz_143)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_148)begin
+    if(_zz_144)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_147)begin
+    if(_zz_143)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_148)begin
-      case(_zz_149)
+    if(_zz_144)begin
+      case(_zz_145)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2301,11 +2416,11 @@ module VexRiscv (
   assign CsrPlugin_allowException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != 3'b000);
-  assign _zz_50 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_51 = (_zz_50 & (~ _zz_183));
-  assign _zz_52 = _zz_51[1];
-  assign _zz_53 = _zz_51[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_140;
+  assign _zz_53 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_54 = (_zz_53 & (~ _zz_190));
+  assign _zz_55 = _zz_54[1];
+  assign _zz_56 = _zz_54[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_139;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -2325,7 +2440,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_185);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_192);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -2365,9 +2480,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_54 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_54);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_54);
+  assign _zz_57 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_57);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_57);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -2376,9 +2491,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_55);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_55);
+  assign _zz_58 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_58);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_58);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -2387,22 +2502,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_56);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_56);
+  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_59);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_59);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_57;
-  assign _zz_57 = ((1'b0 && (! _zz_58)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_58 = _zz_59;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_58;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_60;
+  assign _zz_60 = ((1'b0 && (! _zz_61)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_61 = _zz_62;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_61;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_60)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_60 = _zz_61;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_60;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_62;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_63 = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_63;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_65;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -2424,33 +2539,33 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_130 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_131 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_132 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_131;
+  assign _zz_129 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_130 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_131 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_130;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_134 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_135 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_136 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_133 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_134 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_135 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_145)begin
+    if(_zz_142)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_144)begin
+    if(_zz_141)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_137 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_144)begin
-      _zz_137 = 1'b1;
+    _zz_136 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_141)begin
+      _zz_136 = 1'b1;
     end
   end
 
@@ -2458,8 +2573,8 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_129 = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_64 = 1'b0;
+  assign _zz_128 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_67 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
@@ -2470,39 +2585,39 @@ module VexRiscv (
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_67));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_65 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_68 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_65 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_68 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_65 = execute_RS2[31 : 0];
+        _zz_68 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_65;
+  assign dBus_cmd_payload_data = _zz_68;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_66 = 4'b0001;
+        _zz_69 = 4'b0001;
       end
       2'b01 : begin
-        _zz_66 = 4'b0011;
+        _zz_69 = 4'b0011;
       end
       default : begin
-        _zz_66 = 4'b1111;
+        _zz_69 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_66 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_69 <<< dBus_cmd_payload_address[1 : 0]);
   assign DBusSimplePlugin_mmuBus_cmd_0_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign DBusSimplePlugin_mmuBus_cmd_0_isStuck = execute_arbitration_isStuck;
   assign DBusSimplePlugin_mmuBus_cmd_0_virtualAddress = execute_SRC_ADD;
@@ -2518,7 +2633,7 @@ module VexRiscv (
         DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
       end
     end
-    if(_zz_150)begin
+    if(_zz_146)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
@@ -2538,7 +2653,7 @@ module VexRiscv (
     if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_redoBranch_valid = 1'b1;
     end
-    if(_zz_150)begin
+    if(_zz_146)begin
       DBusSimplePlugin_redoBranch_valid = 1'b0;
     end
   end
@@ -2561,63 +2676,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_67 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_70 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_68[31] = _zz_67;
-    _zz_68[30] = _zz_67;
-    _zz_68[29] = _zz_67;
-    _zz_68[28] = _zz_67;
-    _zz_68[27] = _zz_67;
-    _zz_68[26] = _zz_67;
-    _zz_68[25] = _zz_67;
-    _zz_68[24] = _zz_67;
-    _zz_68[23] = _zz_67;
-    _zz_68[22] = _zz_67;
-    _zz_68[21] = _zz_67;
-    _zz_68[20] = _zz_67;
-    _zz_68[19] = _zz_67;
-    _zz_68[18] = _zz_67;
-    _zz_68[17] = _zz_67;
-    _zz_68[16] = _zz_67;
-    _zz_68[15] = _zz_67;
-    _zz_68[14] = _zz_67;
-    _zz_68[13] = _zz_67;
-    _zz_68[12] = _zz_67;
-    _zz_68[11] = _zz_67;
-    _zz_68[10] = _zz_67;
-    _zz_68[9] = _zz_67;
-    _zz_68[8] = _zz_67;
-    _zz_68[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_71[31] = _zz_70;
+    _zz_71[30] = _zz_70;
+    _zz_71[29] = _zz_70;
+    _zz_71[28] = _zz_70;
+    _zz_71[27] = _zz_70;
+    _zz_71[26] = _zz_70;
+    _zz_71[25] = _zz_70;
+    _zz_71[24] = _zz_70;
+    _zz_71[23] = _zz_70;
+    _zz_71[22] = _zz_70;
+    _zz_71[21] = _zz_70;
+    _zz_71[20] = _zz_70;
+    _zz_71[19] = _zz_70;
+    _zz_71[18] = _zz_70;
+    _zz_71[17] = _zz_70;
+    _zz_71[16] = _zz_70;
+    _zz_71[15] = _zz_70;
+    _zz_71[14] = _zz_70;
+    _zz_71[13] = _zz_70;
+    _zz_71[12] = _zz_70;
+    _zz_71[11] = _zz_70;
+    _zz_71[10] = _zz_70;
+    _zz_71[9] = _zz_70;
+    _zz_71[8] = _zz_70;
+    _zz_71[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_69 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_72 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_70[31] = _zz_69;
-    _zz_70[30] = _zz_69;
-    _zz_70[29] = _zz_69;
-    _zz_70[28] = _zz_69;
-    _zz_70[27] = _zz_69;
-    _zz_70[26] = _zz_69;
-    _zz_70[25] = _zz_69;
-    _zz_70[24] = _zz_69;
-    _zz_70[23] = _zz_69;
-    _zz_70[22] = _zz_69;
-    _zz_70[21] = _zz_69;
-    _zz_70[20] = _zz_69;
-    _zz_70[19] = _zz_69;
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_73[31] = _zz_72;
+    _zz_73[30] = _zz_72;
+    _zz_73[29] = _zz_72;
+    _zz_73[28] = _zz_72;
+    _zz_73[27] = _zz_72;
+    _zz_73[26] = _zz_72;
+    _zz_73[25] = _zz_72;
+    _zz_73[24] = _zz_72;
+    _zz_73[23] = _zz_72;
+    _zz_73[22] = _zz_72;
+    _zz_73[21] = _zz_72;
+    _zz_73[20] = _zz_72;
+    _zz_73[19] = _zz_72;
+    _zz_73[18] = _zz_72;
+    _zz_73[17] = _zz_72;
+    _zz_73[16] = _zz_72;
+    _zz_73[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_166)
+    case(_zz_162)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_68;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_71;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_70;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_73;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2643,51 +2758,49 @@ module VexRiscv (
   assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_72 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_73 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_74 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_75 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_76 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_77 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
-  assign _zz_71 = {(_zz_77 != 1'b0),{({_zz_77,_zz_76} != 2'b00),{(_zz_243 != 1'b0),{(_zz_244 != _zz_245),{_zz_246,{_zz_247,_zz_248}}}}}};
-  assign _zz_78 = _zz_71[2 : 1];
-  assign _zz_47 = _zz_78;
-  assign _zz_79 = _zz_71[7 : 6];
-  assign _zz_46 = _zz_79;
-  assign _zz_80 = _zz_71[14 : 13];
-  assign _zz_45 = _zz_80;
-  assign _zz_81 = _zz_71[17 : 16];
-  assign _zz_44 = _zz_81;
-  assign _zz_82 = _zz_71[20 : 19];
-  assign _zz_43 = _zz_82;
-  assign _zz_83 = _zz_71[23 : 22];
-  assign _zz_42 = _zz_83;
-  assign _zz_84 = _zz_71[26 : 25];
-  assign _zz_41 = _zz_84;
+  assign _zz_75 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_76 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_77 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_78 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_74 = {(((decode_INSTRUCTION & _zz_240) == 32'h02000030) != 1'b0),{((_zz_241 == _zz_242) != 1'b0),{(_zz_243 != 1'b0),{(_zz_244 != _zz_245),{_zz_246,{_zz_247,_zz_248}}}}}};
+  assign _zz_79 = _zz_74[2 : 1];
+  assign _zz_50 = _zz_79;
+  assign _zz_80 = _zz_74[7 : 6];
+  assign _zz_49 = _zz_80;
+  assign _zz_81 = _zz_74[14 : 13];
+  assign _zz_48 = _zz_81;
+  assign _zz_82 = _zz_74[17 : 16];
+  assign _zz_47 = _zz_82;
+  assign _zz_83 = _zz_74[20 : 19];
+  assign _zz_46 = _zz_83;
+  assign _zz_84 = _zz_74[23 : 22];
+  assign _zz_45 = _zz_84;
+  assign _zz_85 = _zz_74[26 : 25];
+  assign _zz_44 = _zz_85;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_138;
-  assign decode_RegFilePlugin_rs2Data = _zz_139;
+  assign decode_RegFilePlugin_rs1Data = _zz_137;
+  assign decode_RegFilePlugin_rs2Data = _zz_138;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_39 && writeBack_arbitration_isFiring);
-    if(_zz_85)begin
+    lastStageRegFileWrite_valid = (_zz_42 && writeBack_arbitration_isFiring);
+    if(_zz_86)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_38[11 : 7];
-    if(_zz_85)begin
+    lastStageRegFileWrite_payload_address = _zz_41[11 : 7];
+    if(_zz_86)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_48;
-    if(_zz_85)begin
+    lastStageRegFileWrite_payload_data = _zz_51;
+    if(_zz_86)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -2709,13 +2822,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_86 = execute_IntAluPlugin_bitwise;
+        _zz_87 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_86 = {31'd0, _zz_186};
+        _zz_87 = {31'd0, _zz_193};
       end
       default : begin
-        _zz_86 = execute_SRC_ADD_SUB;
+        _zz_87 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -2723,232 +2836,265 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_87 = execute_RS1;
+        _zz_88 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_87 = {29'd0, _zz_187};
+        _zz_88 = {29'd0, _zz_194};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_87 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_88 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_87 = {27'd0, _zz_188};
+        _zz_88 = {27'd0, _zz_195};
       end
     endcase
   end
 
-  assign _zz_88 = _zz_189[11];
+  assign _zz_89 = _zz_196[11];
   always @ (*) begin
-    _zz_89[19] = _zz_88;
-    _zz_89[18] = _zz_88;
-    _zz_89[17] = _zz_88;
-    _zz_89[16] = _zz_88;
-    _zz_89[15] = _zz_88;
-    _zz_89[14] = _zz_88;
-    _zz_89[13] = _zz_88;
-    _zz_89[12] = _zz_88;
-    _zz_89[11] = _zz_88;
-    _zz_89[10] = _zz_88;
-    _zz_89[9] = _zz_88;
-    _zz_89[8] = _zz_88;
-    _zz_89[7] = _zz_88;
-    _zz_89[6] = _zz_88;
-    _zz_89[5] = _zz_88;
-    _zz_89[4] = _zz_88;
-    _zz_89[3] = _zz_88;
-    _zz_89[2] = _zz_88;
-    _zz_89[1] = _zz_88;
-    _zz_89[0] = _zz_88;
+    _zz_90[19] = _zz_89;
+    _zz_90[18] = _zz_89;
+    _zz_90[17] = _zz_89;
+    _zz_90[16] = _zz_89;
+    _zz_90[15] = _zz_89;
+    _zz_90[14] = _zz_89;
+    _zz_90[13] = _zz_89;
+    _zz_90[12] = _zz_89;
+    _zz_90[11] = _zz_89;
+    _zz_90[10] = _zz_89;
+    _zz_90[9] = _zz_89;
+    _zz_90[8] = _zz_89;
+    _zz_90[7] = _zz_89;
+    _zz_90[6] = _zz_89;
+    _zz_90[5] = _zz_89;
+    _zz_90[4] = _zz_89;
+    _zz_90[3] = _zz_89;
+    _zz_90[2] = _zz_89;
+    _zz_90[1] = _zz_89;
+    _zz_90[0] = _zz_89;
   end
 
-  assign _zz_90 = _zz_190[11];
+  assign _zz_91 = _zz_197[11];
   always @ (*) begin
-    _zz_91[19] = _zz_90;
-    _zz_91[18] = _zz_90;
-    _zz_91[17] = _zz_90;
-    _zz_91[16] = _zz_90;
-    _zz_91[15] = _zz_90;
-    _zz_91[14] = _zz_90;
-    _zz_91[13] = _zz_90;
-    _zz_91[12] = _zz_90;
-    _zz_91[11] = _zz_90;
-    _zz_91[10] = _zz_90;
-    _zz_91[9] = _zz_90;
-    _zz_91[8] = _zz_90;
-    _zz_91[7] = _zz_90;
-    _zz_91[6] = _zz_90;
-    _zz_91[5] = _zz_90;
-    _zz_91[4] = _zz_90;
-    _zz_91[3] = _zz_90;
-    _zz_91[2] = _zz_90;
-    _zz_91[1] = _zz_90;
-    _zz_91[0] = _zz_90;
+    _zz_92[19] = _zz_91;
+    _zz_92[18] = _zz_91;
+    _zz_92[17] = _zz_91;
+    _zz_92[16] = _zz_91;
+    _zz_92[15] = _zz_91;
+    _zz_92[14] = _zz_91;
+    _zz_92[13] = _zz_91;
+    _zz_92[12] = _zz_91;
+    _zz_92[11] = _zz_91;
+    _zz_92[10] = _zz_91;
+    _zz_92[9] = _zz_91;
+    _zz_92[8] = _zz_91;
+    _zz_92[7] = _zz_91;
+    _zz_92[6] = _zz_91;
+    _zz_92[5] = _zz_91;
+    _zz_92[4] = _zz_91;
+    _zz_92[3] = _zz_91;
+    _zz_92[2] = _zz_91;
+    _zz_92[1] = _zz_91;
+    _zz_92[0] = _zz_91;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_92 = execute_RS2;
+        _zz_93 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_92 = {_zz_89,execute_INSTRUCTION[31 : 20]};
+        _zz_93 = {_zz_90,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_92 = {_zz_91,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_93 = {_zz_92,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_92 = _zz_33;
+        _zz_93 = _zz_36;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_191;
+    execute_SrcPlugin_addSub = _zz_198;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
-  assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
-  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
+  assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_93 = (execute_LightShifterPlugin_shiftInput <<< 1);
-      end
-      default : begin
-        _zz_93 = _zz_198;
-      end
-    endcase
+    _zz_94[0] = execute_SRC1[31];
+    _zz_94[1] = execute_SRC1[30];
+    _zz_94[2] = execute_SRC1[29];
+    _zz_94[3] = execute_SRC1[28];
+    _zz_94[4] = execute_SRC1[27];
+    _zz_94[5] = execute_SRC1[26];
+    _zz_94[6] = execute_SRC1[25];
+    _zz_94[7] = execute_SRC1[24];
+    _zz_94[8] = execute_SRC1[23];
+    _zz_94[9] = execute_SRC1[22];
+    _zz_94[10] = execute_SRC1[21];
+    _zz_94[11] = execute_SRC1[20];
+    _zz_94[12] = execute_SRC1[19];
+    _zz_94[13] = execute_SRC1[18];
+    _zz_94[14] = execute_SRC1[17];
+    _zz_94[15] = execute_SRC1[16];
+    _zz_94[16] = execute_SRC1[15];
+    _zz_94[17] = execute_SRC1[14];
+    _zz_94[18] = execute_SRC1[13];
+    _zz_94[19] = execute_SRC1[12];
+    _zz_94[20] = execute_SRC1[11];
+    _zz_94[21] = execute_SRC1[10];
+    _zz_94[22] = execute_SRC1[9];
+    _zz_94[23] = execute_SRC1[8];
+    _zz_94[24] = execute_SRC1[7];
+    _zz_94[25] = execute_SRC1[6];
+    _zz_94[26] = execute_SRC1[5];
+    _zz_94[27] = execute_SRC1[4];
+    _zz_94[28] = execute_SRC1[3];
+    _zz_94[29] = execute_SRC1[2];
+    _zz_94[30] = execute_SRC1[1];
+    _zz_94[31] = execute_SRC1[0];
+  end
+
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_94 : execute_SRC1);
+  always @ (*) begin
+    _zz_95[0] = memory_SHIFT_RIGHT[31];
+    _zz_95[1] = memory_SHIFT_RIGHT[30];
+    _zz_95[2] = memory_SHIFT_RIGHT[29];
+    _zz_95[3] = memory_SHIFT_RIGHT[28];
+    _zz_95[4] = memory_SHIFT_RIGHT[27];
+    _zz_95[5] = memory_SHIFT_RIGHT[26];
+    _zz_95[6] = memory_SHIFT_RIGHT[25];
+    _zz_95[7] = memory_SHIFT_RIGHT[24];
+    _zz_95[8] = memory_SHIFT_RIGHT[23];
+    _zz_95[9] = memory_SHIFT_RIGHT[22];
+    _zz_95[10] = memory_SHIFT_RIGHT[21];
+    _zz_95[11] = memory_SHIFT_RIGHT[20];
+    _zz_95[12] = memory_SHIFT_RIGHT[19];
+    _zz_95[13] = memory_SHIFT_RIGHT[18];
+    _zz_95[14] = memory_SHIFT_RIGHT[17];
+    _zz_95[15] = memory_SHIFT_RIGHT[16];
+    _zz_95[16] = memory_SHIFT_RIGHT[15];
+    _zz_95[17] = memory_SHIFT_RIGHT[14];
+    _zz_95[18] = memory_SHIFT_RIGHT[13];
+    _zz_95[19] = memory_SHIFT_RIGHT[12];
+    _zz_95[20] = memory_SHIFT_RIGHT[11];
+    _zz_95[21] = memory_SHIFT_RIGHT[10];
+    _zz_95[22] = memory_SHIFT_RIGHT[9];
+    _zz_95[23] = memory_SHIFT_RIGHT[8];
+    _zz_95[24] = memory_SHIFT_RIGHT[7];
+    _zz_95[25] = memory_SHIFT_RIGHT[6];
+    _zz_95[26] = memory_SHIFT_RIGHT[5];
+    _zz_95[27] = memory_SHIFT_RIGHT[4];
+    _zz_95[28] = memory_SHIFT_RIGHT[3];
+    _zz_95[29] = memory_SHIFT_RIGHT[2];
+    _zz_95[30] = memory_SHIFT_RIGHT[1];
+    _zz_95[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_94 = 1'b0;
-    if(_zz_96)begin
-      if((_zz_97 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_94 = 1'b1;
+    _zz_96 = 1'b0;
+    if(_zz_98)begin
+      if((_zz_99 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_96 = 1'b1;
+      end
+    end
+    if(_zz_147)begin
+      if(_zz_148)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_96 = 1'b1;
+        end
+      end
+    end
+    if(_zz_149)begin
+      if(_zz_150)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_96 = 1'b1;
+        end
       end
     end
     if(_zz_151)begin
       if(_zz_152)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_94 = 1'b1;
-        end
-      end
-    end
-    if(_zz_153)begin
-      if(_zz_154)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_94 = 1'b1;
-        end
-      end
-    end
-    if(_zz_155)begin
-      if(_zz_156)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_94 = 1'b1;
+          _zz_96 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_94 = 1'b0;
+      _zz_96 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_95 = 1'b0;
-    if(_zz_96)begin
-      if((_zz_97 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_95 = 1'b1;
+    _zz_97 = 1'b0;
+    if(_zz_98)begin
+      if((_zz_99 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_97 = 1'b1;
+      end
+    end
+    if(_zz_147)begin
+      if(_zz_148)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_97 = 1'b1;
+        end
+      end
+    end
+    if(_zz_149)begin
+      if(_zz_150)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_97 = 1'b1;
+        end
       end
     end
     if(_zz_151)begin
       if(_zz_152)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_95 = 1'b1;
-        end
-      end
-    end
-    if(_zz_153)begin
-      if(_zz_154)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_95 = 1'b1;
-        end
-      end
-    end
-    if(_zz_155)begin
-      if(_zz_156)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_95 = 1'b1;
+          _zz_97 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_95 = 1'b0;
+      _zz_97 = 1'b0;
     end
   end
 
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_98 = execute_INSTRUCTION[14 : 12];
+  assign _zz_100 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_98 == 3'b000)) begin
-        _zz_99 = execute_BranchPlugin_eq;
-    end else if((_zz_98 == 3'b001)) begin
-        _zz_99 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_98 & 3'b101) == 3'b101))) begin
-        _zz_99 = (! execute_SRC_LESS);
+    if((_zz_100 == 3'b000)) begin
+        _zz_101 = execute_BranchPlugin_eq;
+    end else if((_zz_100 == 3'b001)) begin
+        _zz_101 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_100 & 3'b101) == 3'b101))) begin
+        _zz_101 = (! execute_SRC_LESS);
     end else begin
-        _zz_99 = execute_SRC_LESS;
+        _zz_101 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_100 = 1'b0;
+        _zz_102 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_100 = 1'b1;
+        _zz_102 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_100 = 1'b1;
+        _zz_102 = 1'b1;
       end
       default : begin
-        _zz_100 = _zz_99;
+        _zz_102 = _zz_101;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_101 = _zz_200[19];
+  assign _zz_103 = _zz_205[19];
   always @ (*) begin
-    _zz_102[10] = _zz_101;
-    _zz_102[9] = _zz_101;
-    _zz_102[8] = _zz_101;
-    _zz_102[7] = _zz_101;
-    _zz_102[6] = _zz_101;
-    _zz_102[5] = _zz_101;
-    _zz_102[4] = _zz_101;
-    _zz_102[3] = _zz_101;
-    _zz_102[2] = _zz_101;
-    _zz_102[1] = _zz_101;
-    _zz_102[0] = _zz_101;
-  end
-
-  assign _zz_103 = _zz_201[11];
-  always @ (*) begin
-    _zz_104[19] = _zz_103;
-    _zz_104[18] = _zz_103;
-    _zz_104[17] = _zz_103;
-    _zz_104[16] = _zz_103;
-    _zz_104[15] = _zz_103;
-    _zz_104[14] = _zz_103;
-    _zz_104[13] = _zz_103;
-    _zz_104[12] = _zz_103;
-    _zz_104[11] = _zz_103;
     _zz_104[10] = _zz_103;
     _zz_104[9] = _zz_103;
     _zz_104[8] = _zz_103;
@@ -2962,8 +3108,9 @@ module VexRiscv (
     _zz_104[0] = _zz_103;
   end
 
-  assign _zz_105 = _zz_202[11];
+  assign _zz_105 = _zz_206[11];
   always @ (*) begin
+    _zz_106[19] = _zz_105;
     _zz_106[18] = _zz_105;
     _zz_106[17] = _zz_105;
     _zz_106[16] = _zz_105;
@@ -2985,21 +3132,44 @@ module VexRiscv (
     _zz_106[0] = _zz_105;
   end
 
+  assign _zz_107 = _zz_207[11];
+  always @ (*) begin
+    _zz_108[18] = _zz_107;
+    _zz_108[17] = _zz_107;
+    _zz_108[16] = _zz_107;
+    _zz_108[15] = _zz_107;
+    _zz_108[14] = _zz_107;
+    _zz_108[13] = _zz_107;
+    _zz_108[12] = _zz_107;
+    _zz_108[11] = _zz_107;
+    _zz_108[10] = _zz_107;
+    _zz_108[9] = _zz_107;
+    _zz_108[8] = _zz_107;
+    _zz_108[7] = _zz_107;
+    _zz_108[6] = _zz_107;
+    _zz_108[5] = _zz_107;
+    _zz_108[4] = _zz_107;
+    _zz_108[3] = _zz_107;
+    _zz_108[2] = _zz_107;
+    _zz_108[1] = _zz_107;
+    _zz_108[0] = _zz_107;
+  end
+
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_107 = {{_zz_102,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_109 = {{_zz_104,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_107 = {_zz_104,execute_INSTRUCTION[31 : 20]};
+        _zz_109 = {_zz_106,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_107 = {{_zz_106,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_109 = {{_zz_108,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_107;
+  assign execute_BranchPlugin_branch_src2 = _zz_109;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
@@ -3012,9 +3182,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_108 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_109 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_110 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_110 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_111 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_112 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   always @ (*) begin
@@ -3157,7 +3327,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_157)begin
+    if(_zz_153)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -3176,14 +3346,14 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_158)begin
+    if(_zz_154)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_158)begin
+    if(_zz_154)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3198,14 +3368,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_157)begin
+    if(_zz_153)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_157)begin
+    if(_zz_153)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3214,7 +3384,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_167)
+    case(_zz_163)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -3225,70 +3395,72 @@ module VexRiscv (
   end
 
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
+  assign execute_MulPlugin_a = execute_RS1;
+  assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_141)begin
-      if(_zz_146)begin
-        memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
+    case(_zz_155)
+      2'b01 : begin
+        execute_MulPlugin_aSigned = 1'b1;
       end
-    end
+      2'b10 : begin
+        execute_MulPlugin_aSigned = 1'b1;
+      end
+      default : begin
+        execute_MulPlugin_aSigned = 1'b0;
+      end
+    endcase
   end
 
   always @ (*) begin
-    memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! memory_arbitration_isStuck))begin
-      memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
-    end
+    case(_zz_155)
+      2'b01 : begin
+        execute_MulPlugin_bSigned = 1'b1;
+      end
+      2'b10 : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+      default : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+    endcase
   end
 
-  assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
-  assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
-    end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_204);
-    end
-    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
-    end
-  end
-
-  assign _zz_111 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_112 = ((execute_IS_MUL && _zz_111) || 1'b0);
-  always @ (*) begin
-    _zz_113[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_113[31 : 0] = execute_RS1;
-  end
-
-  assign _zz_115 = (_zz_114 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_115 != 32'h0);
-  assign _zz_25 = decode_SRC1_CTRL;
-  assign _zz_23 = _zz_47;
-  assign _zz_35 = decode_to_execute_SRC1_CTRL;
-  assign _zz_22 = decode_SRC2_CTRL;
-  assign _zz_20 = _zz_46;
-  assign _zz_34 = decode_to_execute_SRC2_CTRL;
-  assign _zz_19 = decode_ALU_CTRL;
-  assign _zz_17 = _zz_45;
-  assign _zz_36 = decode_to_execute_ALU_CTRL;
-  assign _zz_16 = decode_ALU_BITWISE_CTRL;
-  assign _zz_14 = _zz_44;
-  assign _zz_37 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_13 = decode_SHIFT_CTRL;
-  assign _zz_11 = _zz_43;
-  assign _zz_32 = decode_to_execute_SHIFT_CTRL;
+  assign execute_MulPlugin_aULow = execute_MulPlugin_a[15 : 0];
+  assign execute_MulPlugin_bULow = execute_MulPlugin_b[15 : 0];
+  assign execute_MulPlugin_aSLow = {1'b0,execute_MulPlugin_a[15 : 0]};
+  assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
+  assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
+  assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
+  assign writeBack_MulPlugin_result = ($signed(_zz_208) + $signed(_zz_209));
+  assign _zz_114 = (_zz_113 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_114 != 32'h0);
+  assign _zz_27 = decode_SRC1_CTRL;
+  assign _zz_25 = _zz_50;
+  assign _zz_38 = decode_to_execute_SRC1_CTRL;
+  assign _zz_24 = decode_SRC2_CTRL;
+  assign _zz_22 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC2_CTRL;
+  assign _zz_21 = decode_ALU_CTRL;
+  assign _zz_19 = _zz_48;
+  assign _zz_39 = decode_to_execute_ALU_CTRL;
+  assign _zz_18 = decode_ALU_BITWISE_CTRL;
+  assign _zz_16 = _zz_47;
+  assign _zz_40 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_15 = decode_SHIFT_CTRL;
+  assign _zz_12 = execute_SHIFT_CTRL;
+  assign _zz_13 = _zz_46;
+  assign _zz_35 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_34 = execute_to_memory_SHIFT_CTRL;
   assign _zz_10 = decode_BRANCH_CTRL;
-  assign _zz_8 = _zz_42;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_8 = _zz_45;
+  assign _zz_32 = decode_to_execute_BRANCH_CTRL;
   assign _zz_7 = decode_ENV_CTRL;
   assign _zz_4 = execute_ENV_CTRL;
   assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_41;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_5 = _zz_44;
+  assign _zz_30 = decode_to_execute_ENV_CTRL;
+  assign _zz_29 = execute_to_memory_ENV_CTRL;
+  assign _zz_31 = memory_to_writeBack_ENV_CTRL;
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3310,105 +3482,105 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_116 = 32'h0;
+    _zz_115 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_116[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_116[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_116[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_115[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_115[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_115[3 : 3] = CsrPlugin_mstatus_MIE;
+    end
+  end
+
+  always @ (*) begin
+    _zz_116 = 32'h0;
+    if(execute_CsrPlugin_csr_836)begin
+      _zz_116[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_116[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_116[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
     _zz_117 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_117[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_117[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_117[3 : 3] = CsrPlugin_mip_MSIP;
+    if(execute_CsrPlugin_csr_772)begin
+      _zz_117[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_117[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_117[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
     _zz_118 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_118[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_118[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_118[3 : 3] = CsrPlugin_mie_MSIE;
+    if(execute_CsrPlugin_csr_833)begin
+      _zz_118[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
     _zz_119 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_119[31 : 0] = CsrPlugin_mepc;
+    if(execute_CsrPlugin_csr_834)begin
+      _zz_119[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_119[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
     _zz_120 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_120[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_120[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    if(execute_CsrPlugin_csr_835)begin
+      _zz_120[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
     _zz_121 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_121[31 : 0] = CsrPlugin_mtval;
+    if(execute_CsrPlugin_csr_2816)begin
+      _zz_121[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
     _zz_122 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_122[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    if(execute_CsrPlugin_csr_2944)begin
+      _zz_122[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
     _zz_123 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_123[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_3008)begin
+      _zz_123[31 : 0] = _zz_113;
     end
   end
 
   always @ (*) begin
     _zz_124 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_4032)begin
       _zz_124[31 : 0] = _zz_114;
     end
   end
 
-  always @ (*) begin
-    _zz_125 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_125[31 : 0] = _zz_115;
-    end
-  end
-
-  assign execute_CsrPlugin_readData = ((((_zz_116 | _zz_117) | (_zz_118 | _zz_119)) | ((_zz_120 | _zz_121) | (_zz_122 | _zz_123))) | (_zz_124 | _zz_125));
-  assign iBusWishbone_ADR = {_zz_221,_zz_126};
-  assign iBusWishbone_CTI = ((_zz_126 == 3'b111) ? 3'b111 : 3'b010);
+  assign execute_CsrPlugin_readData = ((((_zz_115 | _zz_116) | (_zz_117 | _zz_118)) | ((_zz_119 | _zz_120) | (_zz_121 | _zz_122))) | (_zz_123 | _zz_124));
+  assign iBusWishbone_ADR = {_zz_218,_zz_125};
+  assign iBusWishbone_CTI = ((_zz_125 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_159)begin
+    if(_zz_156)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_159)begin
+    if(_zz_156)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_127;
+  assign iBus_rsp_valid = _zz_126;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -3423,19 +3595,19 @@ module VexRiscv (
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_128 = 4'b0001;
+        _zz_127 = 4'b0001;
       end
       2'b01 : begin
-        _zz_128 = 4'b0011;
+        _zz_127 = 4'b0011;
       end
       default : begin
-        _zz_128 = 4'b1111;
+        _zz_127 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_128 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_127 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
       dBusWishbone_SEL = 4'b1111;
     end
@@ -3455,18 +3627,17 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_59 <= 1'b0;
-      _zz_61 <= 1'b0;
+      _zz_62 <= 1'b0;
+      _zz_64 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_63;
+      IBusCachedPlugin_rspCounter <= _zz_66;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_85 <= 1'b1;
-      execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_96 <= 1'b0;
+      _zz_86 <= 1'b1;
+      _zz_98 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3483,13 +3654,12 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      _zz_114 <= 32'h0;
+      _zz_113 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_126 <= 3'b000;
-      _zz_127 <= 1'b0;
+      _zz_125 <= 3'b000;
+      _zz_126 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -3513,16 +3683,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_59 <= 1'b0;
+        _zz_62 <= 1'b0;
       end
-      if(_zz_57)begin
-        _zz_59 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_60)begin
+        _zz_62 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_61 <= 1'b0;
+        _zz_64 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_61 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3589,19 +3759,8 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_85 <= 1'b0;
-      if(_zz_142)begin
-        if(_zz_160)begin
-          execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
-            execute_LightShifterPlugin_isActive <= 1'b0;
-          end
-        end
-      end
-      if(execute_arbitration_removeIt)begin
-        execute_LightShifterPlugin_isActive <= 1'b0;
-      end
-      _zz_96 <= (_zz_39 && writeBack_arbitration_isFiring);
+      _zz_86 <= 1'b0;
+      _zz_98 <= (_zz_42 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3623,14 +3782,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_161)begin
-        if(_zz_162)begin
+      if(_zz_157)begin
+        if(_zz_158)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_163)begin
+        if(_zz_159)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_164)begin
+        if(_zz_160)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3654,7 +3813,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_147)begin
+      if(_zz_143)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3665,8 +3824,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_148)begin
-        case(_zz_149)
+      if(_zz_144)begin
+        case(_zz_145)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3676,8 +3835,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_110,{_zz_109,_zz_108}} != 3'b000) || CsrPlugin_thirdPartyWake);
-      memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
+      execute_CsrPlugin_wfiWake <= (({_zz_112,{_zz_111,_zz_110}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3699,29 +3857,29 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_215[0];
-          CsrPlugin_mstatus_MIE <= _zz_216[0];
+          CsrPlugin_mstatus_MPIE <= _zz_212[0];
+          CsrPlugin_mstatus_MIE <= _zz_213[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_218[0];
-          CsrPlugin_mie_MTIE <= _zz_219[0];
-          CsrPlugin_mie_MSIE <= _zz_220[0];
+          CsrPlugin_mie_MEIE <= _zz_215[0];
+          CsrPlugin_mie_MTIE <= _zz_216[0];
+          CsrPlugin_mie_MSIE <= _zz_217[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_114 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_113 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_159)begin
+      if(_zz_156)begin
         if(iBusWishbone_ACK)begin
-          _zz_126 <= (_zz_126 + 3'b001);
+          _zz_125 <= (_zz_125 + 3'b001);
         end
       end
-      _zz_127 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_165)begin
+      _zz_126 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_161)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3733,7 +3891,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_62 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_65 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -3741,12 +3899,7 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_142)begin
-      if(_zz_160)begin
-        execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
-      end
-    end
-    _zz_97 <= _zz_38[11 : 7];
+    _zz_99 <= _zz_41[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -3766,21 +3919,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusSimplePlugin_memoryExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
     end
-    if(_zz_161)begin
-      if(_zz_162)begin
+    if(_zz_157)begin
+      if(_zz_158)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_163)begin
+      if(_zz_159)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_164)begin
+      if(_zz_160)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_147)begin
+    if(_zz_143)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -3794,23 +3947,12 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_141)begin
-      if(_zz_146)begin
-        memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_205,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
-      end
-    end
-    if((! memory_arbitration_isStuck))begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_112 ? (~ _zz_113) : _zz_113) + _zz_212);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_111 ? (~ execute_RS2) : execute_RS2) + _zz_214);
-    end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_33;
+      execute_to_memory_PC <= _zz_36;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
@@ -3831,10 +3973,10 @@ module VexRiscv (
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_24;
+      decode_to_execute_SRC1_CTRL <= _zz_26;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -3849,7 +3991,7 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_21;
+      decode_to_execute_SRC2_CTRL <= _zz_23;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -3879,16 +4021,19 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_18;
+      decode_to_execute_ALU_CTRL <= _zz_20;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_17;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_12;
+      decode_to_execute_SHIFT_CTRL <= _zz_14;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_11;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BRANCH_CTRL <= _zz_9;
@@ -3911,11 +4056,8 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
@@ -3952,11 +4094,14 @@ module VexRiscv (
       execute_to_memory_MMU_RSP2_refilling <= execute_MMU_RSP2_refilling;
       execute_to_memory_MMU_RSP2_bypassTranslation <= execute_MMU_RSP2_bypassTranslation;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_28;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_26;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_33;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
@@ -3964,8 +4109,26 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -4002,7 +4165,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_217[0];
+        CsrPlugin_mip_MSIP <= _zz_214[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -4017,7 +4180,7 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_165)begin
+    if(_zz_161)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -4071,12 +4234,12 @@ module InstructionCache (
   input               reset
 );
   reg        [31:0]   _zz_9;
-  reg        [24:0]   _zz_10;
+  reg        [22:0]   _zz_10;
   wire                _zz_11;
   wire                _zz_12;
   wire       [0:0]    _zz_13;
   wire       [0:0]    _zz_14;
-  wire       [24:0]   _zz_15;
+  wire       [22:0]   _zz_15;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -4084,7 +4247,7 @@ module InstructionCache (
   (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
-  reg        [4:0]    lineLoader_flushCounter;
+  reg        [6:0]    lineLoader_flushCounter;
   reg                 _zz_3;
   reg                 lineLoader_cmdSent;
   reg                 lineLoader_wayToAllocate_willIncrement;
@@ -4093,23 +4256,23 @@ module InstructionCache (
   wire                lineLoader_wayToAllocate_willOverflow;
   (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
   wire                lineLoader_write_tag_0_valid;
-  wire       [3:0]    lineLoader_write_tag_0_payload_address;
+  wire       [5:0]    lineLoader_write_tag_0_payload_address;
   wire                lineLoader_write_tag_0_payload_data_valid;
   wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [22:0]   lineLoader_write_tag_0_payload_data_address;
+  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
   wire                lineLoader_write_data_0_valid;
-  wire       [6:0]    lineLoader_write_data_0_payload_address;
+  wire       [8:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [6:0]    _zz_4;
+  wire       [8:0]    _zz_4;
   wire                _zz_5;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [3:0]    _zz_6;
+  wire       [5:0]    _zz_6;
   wire                _zz_7;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [22:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [24:0]   _zz_8;
+  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [22:0]   _zz_8;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
@@ -4127,10 +4290,10 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_bypassTranslation;
   reg                 decodeStage_hit_valid;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:127];
-  (* ram_style = "block" *) reg [24:0] ways_0_tags [0:15];
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
-  assign _zz_11 = (! lineLoader_flushCounter[4]);
+  assign _zz_11 = (! lineLoader_flushCounter[6]);
   assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign _zz_13 = _zz_8[0 : 0];
   assign _zz_14 = _zz_8[1 : 1];
@@ -4208,25 +4371,25 @@ module InstructionCache (
   assign lineLoader_wayToAllocate_willClear = 1'b0;
   assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
   assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[4]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[4] ? lineLoader_address[8 : 5] : lineLoader_flushCounter[3 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[4];
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[6]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
   assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 9];
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[8 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[8 : 2];
+  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
   assign _zz_5 = (! io_cpu_fetch_isStuck);
   assign fetchStage_read_banksValue_0_dataMem = _zz_9;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[8 : 5];
+  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
   assign _zz_7 = (! io_cpu_fetch_isStuck);
   assign _zz_8 = _zz_10;
   assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
   assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[24 : 2];
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 9]));
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
@@ -4282,11 +4445,11 @@ module InstructionCache (
       lineLoader_address <= io_cpu_fill_payload;
     end
     if(_zz_11)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 5'h01);
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[4];
+    _zz_3 <= lineLoader_flushCounter[6];
     if(_zz_12)begin
-      lineLoader_flushCounter <= 5'h0;
+      lineLoader_flushCounter <= 7'h0;
     end
     if((! io_cpu_decode_isStuck))begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.yaml
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Fomu.yaml
@@ -1,4 +1,4 @@
 iBus: !!vexriscv.BusReport
   flushInstructions: [4111, 19, 19, 19]
-  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 512}
+  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 2048}
   kind: cached

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.v
@@ -1,6 +1,6 @@
 // Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
-// Git hash  : 43e13174d8583db5f4cd45d2b3515bc206a0010a
+// Git hash  : d8ec2d84c3160c3a9131beef2db359dce7a2e4a4
 
 
 `define Input2Kind_defaultEncoding_type [0:0]
@@ -86,6 +86,7 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  wire                _zz_143;
   wire                _zz_144;
   wire                _zz_145;
   wire                _zz_146;
@@ -93,11 +94,10 @@ module VexRiscv (
   wire                _zz_148;
   wire                _zz_149;
   wire                _zz_150;
-  wire                _zz_151;
-  reg                 _zz_152;
+  reg                 _zz_151;
+  reg        [31:0]   _zz_152;
   reg        [31:0]   _zz_153;
   reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -110,22 +110,23 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
+  wire                _zz_155;
   wire                _zz_156;
   wire                _zz_157;
   wire                _zz_158;
   wire                _zz_159;
   wire                _zz_160;
-  wire                _zz_161;
+  wire       [1:0]    _zz_161;
   wire                _zz_162;
   wire                _zz_163;
   wire                _zz_164;
-  wire       [1:0]    _zz_165;
+  wire                _zz_165;
   wire                _zz_166;
   wire                _zz_167;
   wire                _zz_168;
   wire                _zz_169;
   wire                _zz_170;
-  wire                _zz_171;
+  wire       [1:0]    _zz_171;
   wire                _zz_172;
   wire                _zz_173;
   wire                _zz_174;
@@ -133,21 +134,21 @@ module VexRiscv (
   wire                _zz_176;
   wire                _zz_177;
   wire                _zz_178;
-  wire                _zz_179;
+  wire       [1:0]    _zz_179;
   wire                _zz_180;
-  wire                _zz_181;
-  wire                _zz_182;
-  wire       [1:0]    _zz_183;
-  wire                _zz_184;
-  wire       [0:0]    _zz_185;
-  wire       [0:0]    _zz_186;
-  wire       [0:0]    _zz_187;
-  wire       [0:0]    _zz_188;
-  wire       [0:0]    _zz_189;
-  wire       [0:0]    _zz_190;
-  wire       [0:0]    _zz_191;
-  wire       [0:0]    _zz_192;
-  wire       [0:0]    _zz_193;
+  wire       [1:0]    _zz_181;
+  wire       [51:0]   _zz_182;
+  wire       [51:0]   _zz_183;
+  wire       [51:0]   _zz_184;
+  wire       [32:0]   _zz_185;
+  wire       [51:0]   _zz_186;
+  wire       [49:0]   _zz_187;
+  wire       [51:0]   _zz_188;
+  wire       [49:0]   _zz_189;
+  wire       [51:0]   _zz_190;
+  wire       [32:0]   _zz_191;
+  wire       [31:0]   _zz_192;
+  wire       [32:0]   _zz_193;
   wire       [0:0]    _zz_194;
   wire       [0:0]    _zz_195;
   wire       [0:0]    _zz_196;
@@ -155,213 +156,222 @@ module VexRiscv (
   wire       [0:0]    _zz_198;
   wire       [0:0]    _zz_199;
   wire       [0:0]    _zz_200;
-  wire       [2:0]    _zz_201;
-  wire       [2:0]    _zz_202;
-  wire       [31:0]   _zz_203;
+  wire       [0:0]    _zz_201;
+  wire       [0:0]    _zz_202;
+  wire       [0:0]    _zz_203;
   wire       [0:0]    _zz_204;
-  wire       [2:0]    _zz_205;
-  wire       [4:0]    _zz_206;
-  wire       [11:0]   _zz_207;
-  wire       [11:0]   _zz_208;
-  wire       [31:0]   _zz_209;
+  wire       [0:0]    _zz_205;
+  wire       [0:0]    _zz_206;
+  wire       [0:0]    _zz_207;
+  wire       [2:0]    _zz_208;
+  wire       [2:0]    _zz_209;
   wire       [31:0]   _zz_210;
-  wire       [31:0]   _zz_211;
-  wire       [31:0]   _zz_212;
-  wire       [31:0]   _zz_213;
-  wire       [31:0]   _zz_214;
-  wire       [31:0]   _zz_215;
+  wire       [0:0]    _zz_211;
+  wire       [2:0]    _zz_212;
+  wire       [4:0]    _zz_213;
+  wire       [11:0]   _zz_214;
+  wire       [11:0]   _zz_215;
   wire       [31:0]   _zz_216;
-  wire       [32:0]   _zz_217;
-  wire       [19:0]   _zz_218;
-  wire       [11:0]   _zz_219;
-  wire       [11:0]   _zz_220;
-  wire       [1:0]    _zz_221;
-  wire       [1:0]    _zz_222;
-  wire       [9:0]    _zz_223;
-  wire       [7:0]    _zz_224;
-  wire       [0:0]    _zz_225;
-  wire       [5:0]    _zz_226;
-  wire       [33:0]   _zz_227;
-  wire       [32:0]   _zz_228;
-  wire       [33:0]   _zz_229;
-  wire       [32:0]   _zz_230;
-  wire       [33:0]   _zz_231;
-  wire       [32:0]   _zz_232;
-  wire       [0:0]    _zz_233;
-  wire       [32:0]   _zz_234;
+  wire       [31:0]   _zz_217;
+  wire       [31:0]   _zz_218;
+  wire       [31:0]   _zz_219;
+  wire       [31:0]   _zz_220;
+  wire       [31:0]   _zz_221;
+  wire       [31:0]   _zz_222;
+  wire       [19:0]   _zz_223;
+  wire       [11:0]   _zz_224;
+  wire       [11:0]   _zz_225;
+  wire       [1:0]    _zz_226;
+  wire       [1:0]    _zz_227;
+  wire       [9:0]    _zz_228;
+  wire       [7:0]    _zz_229;
+  wire       [65:0]   _zz_230;
+  wire       [65:0]   _zz_231;
+  wire       [31:0]   _zz_232;
+  wire       [31:0]   _zz_233;
+  wire       [0:0]    _zz_234;
   wire       [0:0]    _zz_235;
-  wire       [31:0]   _zz_236;
+  wire       [0:0]    _zz_236;
   wire       [0:0]    _zz_237;
   wire       [0:0]    _zz_238;
   wire       [0:0]    _zz_239;
-  wire       [0:0]    _zz_240;
-  wire       [0:0]    _zz_241;
-  wire       [0:0]    _zz_242;
-  wire       [26:0]   _zz_243;
-  wire                _zz_244;
-  wire                _zz_245;
-  wire       [1:0]    _zz_246;
-  wire       [31:0]   _zz_247;
-  wire       [31:0]   _zz_248;
-  wire       [31:0]   _zz_249;
-  wire                _zz_250;
-  wire       [0:0]    _zz_251;
-  wire       [14:0]   _zz_252;
-  wire       [31:0]   _zz_253;
-  wire       [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire                _zz_256;
-  wire       [0:0]    _zz_257;
-  wire       [8:0]    _zz_258;
-  wire       [31:0]   _zz_259;
-  wire       [31:0]   _zz_260;
-  wire       [31:0]   _zz_261;
+  wire       [26:0]   _zz_240;
+  wire                _zz_241;
+  wire                _zz_242;
+  wire       [1:0]    _zz_243;
+  wire       [31:0]   _zz_244;
+  wire       [31:0]   _zz_245;
+  wire       [31:0]   _zz_246;
+  wire                _zz_247;
+  wire       [0:0]    _zz_248;
+  wire       [14:0]   _zz_249;
+  wire       [31:0]   _zz_250;
+  wire       [31:0]   _zz_251;
+  wire       [31:0]   _zz_252;
+  wire                _zz_253;
+  wire       [0:0]    _zz_254;
+  wire       [8:0]    _zz_255;
+  wire       [31:0]   _zz_256;
+  wire       [31:0]   _zz_257;
+  wire       [31:0]   _zz_258;
+  wire                _zz_259;
+  wire       [0:0]    _zz_260;
+  wire       [2:0]    _zz_261;
   wire                _zz_262;
   wire       [0:0]    _zz_263;
-  wire       [2:0]    _zz_264;
-  wire       [31:0]   _zz_265;
-  wire       [31:0]   _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [0:0]    _zz_268;
-  wire                _zz_269;
-  wire       [0:0]    _zz_270;
-  wire       [24:0]   _zz_271;
-  wire       [31:0]   _zz_272;
+  wire       [0:0]    _zz_264;
+  wire                _zz_265;
+  wire       [0:0]    _zz_266;
+  wire       [22:0]   _zz_267;
+  wire       [31:0]   _zz_268;
+  wire       [31:0]   _zz_269;
+  wire       [31:0]   _zz_270;
+  wire       [31:0]   _zz_271;
+  wire                _zz_272;
   wire                _zz_273;
-  wire                _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
+  wire       [1:0]    _zz_274;
+  wire       [1:0]    _zz_275;
+  wire                _zz_276;
   wire       [0:0]    _zz_277;
-  wire       [0:0]    _zz_278;
-  wire                _zz_279;
-  wire       [0:0]    _zz_280;
-  wire       [19:0]   _zz_281;
+  wire       [18:0]   _zz_278;
+  wire       [31:0]   _zz_279;
+  wire       [31:0]   _zz_280;
+  wire       [31:0]   _zz_281;
   wire       [31:0]   _zz_282;
   wire       [31:0]   _zz_283;
-  wire                _zz_284;
-  wire                _zz_285;
-  wire                _zz_286;
-  wire       [2:0]    _zz_287;
-  wire       [2:0]    _zz_288;
+  wire       [31:0]   _zz_284;
+  wire       [0:0]    _zz_285;
+  wire       [1:0]    _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [0:0]    _zz_288;
   wire                _zz_289;
   wire       [0:0]    _zz_290;
-  wire       [16:0]   _zz_291;
+  wire       [15:0]   _zz_291;
   wire       [31:0]   _zz_292;
   wire       [31:0]   _zz_293;
-  wire                _zz_294;
-  wire                _zz_295;
-  wire                _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [0:0]    _zz_298;
-  wire                _zz_299;
-  wire       [0:0]    _zz_300;
-  wire       [0:0]    _zz_301;
-  wire                _zz_302;
-  wire       [0:0]    _zz_303;
-  wire       [13:0]   _zz_304;
-  wire       [31:0]   _zz_305;
+  wire       [31:0]   _zz_294;
+  wire       [31:0]   _zz_295;
+  wire       [31:0]   _zz_296;
+  wire       [31:0]   _zz_297;
+  wire       [31:0]   _zz_298;
+  wire       [31:0]   _zz_299;
+  wire                _zz_300;
+  wire       [1:0]    _zz_301;
+  wire       [1:0]    _zz_302;
+  wire                _zz_303;
+  wire       [0:0]    _zz_304;
+  wire       [12:0]   _zz_305;
   wire       [31:0]   _zz_306;
   wire       [31:0]   _zz_307;
   wire       [31:0]   _zz_308;
   wire       [31:0]   _zz_309;
   wire       [31:0]   _zz_310;
   wire       [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [0:0]    _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [1:0]    _zz_315;
-  wire       [1:0]    _zz_316;
-  wire                _zz_317;
-  wire       [0:0]    _zz_318;
-  wire       [11:0]   _zz_319;
+  wire       [2:0]    _zz_312;
+  wire       [2:0]    _zz_313;
+  wire                _zz_314;
+  wire       [0:0]    _zz_315;
+  wire       [9:0]    _zz_316;
+  wire       [31:0]   _zz_317;
+  wire       [31:0]   _zz_318;
+  wire       [31:0]   _zz_319;
   wire       [31:0]   _zz_320;
   wire       [31:0]   _zz_321;
-  wire       [31:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire       [31:0]   _zz_325;
-  wire       [0:0]    _zz_326;
-  wire       [1:0]    _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [0:0]    _zz_329;
-  wire                _zz_330;
-  wire       [0:0]    _zz_331;
-  wire       [8:0]    _zz_332;
+  wire                _zz_322;
+  wire       [0:0]    _zz_323;
+  wire       [2:0]    _zz_324;
+  wire       [0:0]    _zz_325;
+  wire       [3:0]    _zz_326;
+  wire       [5:0]    _zz_327;
+  wire       [5:0]    _zz_328;
+  wire                _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [5:0]    _zz_331;
+  wire       [31:0]   _zz_332;
   wire       [31:0]   _zz_333;
   wire       [31:0]   _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [31:0]   _zz_336;
-  wire       [31:0]   _zz_337;
-  wire                _zz_338;
-  wire                _zz_339;
+  wire       [0:0]    _zz_335;
+  wire       [0:0]    _zz_336;
+  wire                _zz_337;
+  wire       [0:0]    _zz_338;
+  wire       [1:0]    _zz_339;
   wire       [0:0]    _zz_340;
-  wire       [1:0]    _zz_341;
-  wire       [5:0]    _zz_342;
-  wire       [5:0]    _zz_343;
-  wire                _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [5:0]    _zz_346;
-  wire       [31:0]   _zz_347;
-  wire       [31:0]   _zz_348;
+  wire       [3:0]    _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [1:0]    _zz_344;
+  wire       [1:0]    _zz_345;
+  wire                _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [3:0]    _zz_348;
   wire       [31:0]   _zz_349;
   wire       [31:0]   _zz_350;
-  wire                _zz_351;
-  wire       [0:0]    _zz_352;
-  wire       [2:0]    _zz_353;
-  wire                _zz_354;
-  wire       [0:0]    _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [3:0]    _zz_357;
-  wire       [3:0]    _zz_358;
-  wire                _zz_359;
-  wire       [0:0]    _zz_360;
-  wire       [2:0]    _zz_361;
-  wire       [31:0]   _zz_362;
+  wire       [31:0]   _zz_351;
+  wire       [31:0]   _zz_352;
+  wire       [31:0]   _zz_353;
+  wire       [31:0]   _zz_354;
+  wire       [31:0]   _zz_355;
+  wire                _zz_356;
+  wire                _zz_357;
+  wire       [31:0]   _zz_358;
+  wire       [31:0]   _zz_359;
+  wire                _zz_360;
+  wire       [0:0]    _zz_361;
+  wire       [1:0]    _zz_362;
   wire       [31:0]   _zz_363;
   wire       [31:0]   _zz_364;
   wire                _zz_365;
   wire       [0:0]    _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [31:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire                _zz_371;
-  wire       [0:0]    _zz_372;
-  wire       [1:0]    _zz_373;
-  wire                _zz_374;
-  wire       [2:0]    _zz_375;
-  wire       [2:0]    _zz_376;
-  wire                _zz_377;
-  wire       [0:0]    _zz_378;
-  wire       [0:0]    _zz_379;
+  wire       [2:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [0:0]    _zz_369;
+  wire                _zz_370;
+  wire       [0:0]    _zz_371;
+  wire       [1:0]    _zz_372;
+  wire       [31:0]   _zz_373;
+  wire       [31:0]   _zz_374;
+  wire       [31:0]   _zz_375;
+  wire       [31:0]   _zz_376;
+  wire       [31:0]   _zz_377;
+  wire                _zz_378;
+  wire                _zz_379;
   wire       [31:0]   _zz_380;
   wire       [31:0]   _zz_381;
   wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire       [31:0]   _zz_384;
-  wire       [31:0]   _zz_385;
+  wire                _zz_383;
+  wire       [0:0]    _zz_384;
+  wire       [0:0]    _zz_385;
   wire       [31:0]   _zz_386;
   wire       [31:0]   _zz_387;
-  wire                _zz_388;
-  wire       [31:0]   _zz_389;
-  wire                _zz_390;
-  wire       [0:0]    _zz_391;
-  wire       [0:0]    _zz_392;
-  wire       [0:0]    _zz_393;
-  wire       [0:0]    _zz_394;
-  wire       [1:0]    _zz_395;
-  wire       [1:0]    _zz_396;
-  wire       [0:0]    _zz_397;
-  wire       [0:0]    _zz_398;
+  wire       [0:0]    _zz_388;
+  wire       [1:0]    _zz_389;
+  wire       [1:0]    _zz_390;
+  wire       [1:0]    _zz_391;
+  wire                _zz_392;
+  wire                _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire       [31:0]   _zz_398;
   wire       [31:0]   _zz_399;
   wire       [31:0]   _zz_400;
-  wire       [31:0]   _zz_401;
-  wire       [31:0]   _zz_402;
-  wire       [31:0]   _zz_403;
-  wire       [31:0]   _zz_404;
+  wire                _zz_401;
+  wire                _zz_402;
+  wire                _zz_403;
+  wire       [0:0]    _zz_404;
+  wire       [0:0]    _zz_405;
+  wire                _zz_406;
+  wire       [51:0]   memory_MUL_LOW;
   wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
   wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
   wire                execute_CfuPlugin_CFU_IN_FLIGHT;
+  wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
@@ -371,8 +381,8 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_IS_RS1_SIGNED;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
   wire                decode_IS_MUL;
   wire       `Input2Kind_defaultEncoding_type decode_CfuPlugin_CFU_INPUT_2_KIND;
   wire       `Input2Kind_defaultEncoding_type _zz_1;
@@ -392,61 +402,65 @@ module VexRiscv (
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
   wire       `BranchCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_18;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_21;
   wire                decode_SRC_LESS_UNSIGNED;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
   wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24;
   wire       `Src2CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_27;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
   wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_29;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_30;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                execute_IS_RS1_SIGNED;
-  wire                execute_IS_MUL;
-  wire                execute_IS_RS2_SIGNED;
-  wire                memory_IS_MUL;
-  reg                 _zz_29;
-  reg                 _zz_30;
-  reg        [31:0]   _zz_31;
+  wire                writeBack_IS_MUL;
+  wire       [33:0]   writeBack_MUL_HH;
+  wire       [51:0]   writeBack_MUL_LOW;
+  wire       [33:0]   memory_MUL_HL;
+  wire       [33:0]   memory_MUL_LH;
+  wire       [31:0]   memory_MUL_LL;
+  reg                 _zz_31;
+  reg                 _zz_32;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_32;
+  wire       `Input2Kind_defaultEncoding_type _zz_33;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  reg        [31:0]   _zz_34;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
-  wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
-  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_36;
+  wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_37;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
-  wire       [31:0]   execute_RS1;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_38;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -455,43 +469,46 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_37;
+  wire       [31:0]   memory_SHIFT_RIGHT;
+  reg        [31:0]   _zz_39;
+  wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_41;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_39;
+  wire       [31:0]   _zz_42;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_40;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_43;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_41;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_44;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
-  wire       [31:0]   _zz_44;
-  wire                _zz_45;
-  reg                 _zz_46;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       [31:0]   _zz_47;
+  wire                _zz_48;
+  reg                 _zz_49;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_defaultEncoding_type _zz_47;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_49;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_50;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_51;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_52;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_53;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_54;
+  wire       `Input2Kind_defaultEncoding_type _zz_50;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_53;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_54;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_55;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_56;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_57;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_55;
+  reg        [31:0]   _zz_58;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -520,7 +537,7 @@ module VexRiscv (
   wire                execute_MMU_RSP2_refilling;
   wire                execute_MMU_RSP2_bypassTranslation;
   wire       [31:0]   execute_SRC_ADD;
-  wire       [31:0]   execute_RS2;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
@@ -530,8 +547,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_56;
-  reg        [31:0]   _zz_57;
+  reg        [31:0]   _zz_59;
+  reg        [31:0]   _zz_60;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -652,10 +669,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_58;
-  wire       [2:0]    _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire       [2:0]    _zz_61;
+  wire       [2:0]    _zz_62;
+  wire                _zz_63;
+  wire                _zz_64;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -692,16 +709,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_62;
-  wire                _zz_63;
-  wire                _zz_64;
-  wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_65;
   wire                _zz_66;
-  reg                 _zz_67;
+  wire                _zz_67;
+  wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_68;
-  reg                 _zz_69;
-  reg        [31:0]   _zz_70;
+  wire                _zz_69;
+  reg                 _zz_70;
+  wire                _zz_71;
+  reg                 _zz_72;
+  reg        [31:0]   _zz_73;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -721,7 +738,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_71;
+  wire       [31:0]   _zz_74;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -738,33 +755,31 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_72;
+  wire                _zz_75;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_73;
-  reg        [3:0]    _zz_74;
+  reg        [31:0]   _zz_76;
+  reg        [3:0]    _zz_77;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_75;
-  reg        [31:0]   _zz_76;
-  wire                _zz_77;
-  reg        [31:0]   _zz_78;
-  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [31:0]   _zz_79;
+  wire                _zz_78;
+  reg        [31:0]   _zz_79;
   wire                _zz_80;
-  wire                _zz_81;
-  wire                _zz_82;
+  reg        [31:0]   _zz_81;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
+  wire       [29:0]   _zz_82;
   wire                _zz_83;
   wire                _zz_84;
   wire                _zz_85;
   wire                _zz_86;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_87;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_88;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_89;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_90;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_91;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_92;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `Input2Kind_defaultEncoding_type _zz_94;
+  wire                _zz_87;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_88;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_89;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_90;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_91;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_92;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_93;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_94;
+  wire       `Input2Kind_defaultEncoding_type _zz_95;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -772,40 +787,37 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_95;
+  reg                 _zz_96;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_96;
   reg        [31:0]   _zz_97;
-  wire                _zz_98;
-  reg        [19:0]   _zz_99;
-  wire                _zz_100;
-  reg        [19:0]   _zz_101;
-  reg        [31:0]   _zz_102;
+  reg        [31:0]   _zz_98;
+  wire                _zz_99;
+  reg        [19:0]   _zz_100;
+  wire                _zz_101;
+  reg        [19:0]   _zz_102;
+  reg        [31:0]   _zz_103;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
-  reg                 execute_LightShifterPlugin_isActive;
-  wire                execute_LightShifterPlugin_isShift;
-  reg        [4:0]    execute_LightShifterPlugin_amplitudeReg;
-  wire       [4:0]    execute_LightShifterPlugin_amplitude;
-  wire       [31:0]   execute_LightShifterPlugin_shiftInput;
-  wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_103;
-  reg                 _zz_104;
-  reg                 _zz_105;
+  wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
+  reg        [31:0]   _zz_104;
+  wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
+  reg        [31:0]   _zz_105;
   reg                 _zz_106;
-  reg        [4:0]    _zz_107;
+  reg                 _zz_107;
+  reg                 _zz_108;
+  reg        [4:0]    _zz_109;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
+  wire       [2:0]    _zz_110;
+  reg                 _zz_111;
+  reg                 _zz_112;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_111;
-  reg        [10:0]   _zz_112;
   wire                _zz_113;
-  reg        [19:0]   _zz_114;
+  reg        [10:0]   _zz_114;
   wire                _zz_115;
-  reg        [18:0]   _zz_116;
-  reg        [31:0]   _zz_117;
+  reg        [19:0]   _zz_116;
+  wire                _zz_117;
+  reg        [18:0]   _zz_118;
+  reg        [31:0]   _zz_119;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -827,9 +839,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_118;
-  wire                _zz_119;
   wire                _zz_120;
+  wire                _zz_121;
+  wire                _zz_122;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -842,8 +854,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_121;
-  wire                _zz_122;
+  wire       [1:0]    _zz_123;
+  wire                _zz_124;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -876,9 +888,9 @@ module VexRiscv (
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
-  wire                _zz_123;
-  reg        [23:0]   _zz_124;
-  reg        [31:0]   _zz_125;
+  wire                _zz_125;
+  reg        [23:0]   _zz_126;
+  reg        [31:0]   _zz_127;
   wire                memory_CfuPlugin_rsp_valid;
   reg                 memory_CfuPlugin_rsp_ready;
   wire                memory_CfuPlugin_rsp_payload_response_ok;
@@ -886,22 +898,20 @@ module VexRiscv (
   reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
   reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
   reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
-  reg        [32:0]   memory_MulDivIterativePlugin_rs1;
-  reg        [31:0]   memory_MulDivIterativePlugin_rs2;
-  reg        [64:0]   memory_MulDivIterativePlugin_accumulator;
-  wire                memory_MulDivIterativePlugin_frontendOk;
-  reg                 memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  reg                 memory_MulDivIterativePlugin_mul_counter_willClear;
-  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_valueNext;
-  reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
-  wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
-  wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
-  wire                _zz_126;
-  wire                _zz_127;
-  reg        [32:0]   _zz_128;
+  reg                 execute_MulPlugin_aSigned;
+  reg                 execute_MulPlugin_bSigned;
+  wire       [31:0]   execute_MulPlugin_a;
+  wire       [31:0]   execute_MulPlugin_b;
+  wire       [15:0]   execute_MulPlugin_aULow;
+  wire       [15:0]   execute_MulPlugin_bULow;
+  wire       [16:0]   execute_MulPlugin_aSLow;
+  wire       [16:0]   execute_MulPlugin_bSLow;
+  wire       [16:0]   execute_MulPlugin_aHigh;
+  wire       [16:0]   execute_MulPlugin_bHigh;
+  wire       [65:0]   writeBack_MulPlugin_result;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_129;
-  wire       [31:0]   _zz_130;
+  reg        [31:0]   _zz_128;
+  wire       [31:0]   _zz_129;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
@@ -930,6 +940,7 @@ module VexRiscv (
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
@@ -939,8 +950,7 @@ module VexRiscv (
   reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   reg                 decode_to_execute_IS_MUL;
   reg                 execute_to_memory_IS_MUL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
@@ -960,9 +970,16 @@ module VexRiscv (
   reg                 execute_to_memory_MMU_RSP2_bypassTranslation;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -974,6 +991,7 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_2944;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_130;
   reg        [31:0]   _zz_131;
   reg        [31:0]   _zz_132;
   reg        [31:0]   _zz_133;
@@ -983,9 +1001,8 @@ module VexRiscv (
   reg        [31:0]   _zz_137;
   reg        [31:0]   _zz_138;
   reg        [31:0]   _zz_139;
-  reg        [31:0]   _zz_140;
-  reg        [2:0]    _zz_141;
-  reg                 _zz_142;
+  reg        [2:0]    _zz_140;
+  reg                 _zz_141;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -999,7 +1016,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_143;
+  reg        [3:0]    _zz_142;
   `ifndef SYNTHESIS
   reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] _zz_1_string;
@@ -1017,67 +1034,72 @@ module VexRiscv (
   reg [31:0] _zz_11_string;
   reg [31:0] _zz_12_string;
   reg [31:0] _zz_13_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
   reg [71:0] _zz_14_string;
   reg [71:0] _zz_15_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
   reg [71:0] _zz_16_string;
+  reg [71:0] _zz_17_string;
+  reg [71:0] _zz_18_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_17_string;
-  reg [39:0] _zz_18_string;
   reg [39:0] _zz_19_string;
+  reg [39:0] _zz_20_string;
+  reg [39:0] _zz_21_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_20_string;
-  reg [63:0] _zz_21_string;
   reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_24_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_23_string;
-  reg [23:0] _zz_24_string;
   reg [23:0] _zz_25_string;
+  reg [23:0] _zz_26_string;
+  reg [23:0] _zz_27_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_26_string;
-  reg [95:0] _zz_27_string;
   reg [95:0] _zz_28_string;
+  reg [95:0] _zz_29_string;
+  reg [95:0] _zz_30_string;
   reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
-  reg [39:0] _zz_32_string;
-  reg [39:0] memory_ENV_CTRL_string;
   reg [39:0] _zz_33_string;
-  reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_34_string;
-  reg [39:0] writeBack_ENV_CTRL_string;
+  reg [39:0] memory_ENV_CTRL_string;
   reg [39:0] _zz_35_string;
+  reg [39:0] execute_ENV_CTRL_string;
+  reg [39:0] _zz_36_string;
+  reg [39:0] writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_37_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_36_string;
+  reg [31:0] _zz_38_string;
+  reg [71:0] memory_SHIFT_CTRL_string;
+  reg [71:0] _zz_40_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_38_string;
+  reg [71:0] _zz_41_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_40_string;
+  reg [23:0] _zz_43_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_41_string;
+  reg [95:0] _zz_44_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_42_string;
+  reg [63:0] _zz_45_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_43_string;
-  reg [39:0] _zz_47_string;
-  reg [39:0] _zz_48_string;
-  reg [31:0] _zz_49_string;
-  reg [71:0] _zz_50_string;
+  reg [39:0] _zz_46_string;
+  reg [39:0] _zz_50_string;
   reg [39:0] _zz_51_string;
-  reg [63:0] _zz_52_string;
-  reg [23:0] _zz_53_string;
-  reg [95:0] _zz_54_string;
-  reg [95:0] _zz_87_string;
-  reg [23:0] _zz_88_string;
-  reg [63:0] _zz_89_string;
-  reg [39:0] _zz_90_string;
-  reg [71:0] _zz_91_string;
-  reg [31:0] _zz_92_string;
-  reg [39:0] _zz_93_string;
+  reg [31:0] _zz_52_string;
+  reg [71:0] _zz_53_string;
+  reg [39:0] _zz_54_string;
+  reg [63:0] _zz_55_string;
+  reg [23:0] _zz_56_string;
+  reg [95:0] _zz_57_string;
+  reg [95:0] _zz_88_string;
+  reg [23:0] _zz_89_string;
+  reg [63:0] _zz_90_string;
+  reg [39:0] _zz_91_string;
+  reg [71:0] _zz_92_string;
+  reg [31:0] _zz_93_string;
   reg [39:0] _zz_94_string;
+  reg [39:0] _zz_95_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1087,281 +1109,284 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_156 = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_157 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_158 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_159 = ((_zz_149 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_160 = ((_zz_149 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_161 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_162 = ({CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_163 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_164 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_165 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_166 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_167 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_168 = (1'b1 || (! 1'b1));
-  assign _zz_169 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_170 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_171 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_172 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_173 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_174 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_175 = (iBus_cmd_valid || (_zz_141 != 3'b000));
-  assign _zz_176 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_177 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_178 = ((_zz_118 && 1'b1) && (! 1'b0));
-  assign _zz_179 = ((_zz_119 && 1'b1) && (! 1'b0));
-  assign _zz_180 = ((_zz_120 && 1'b1) && (! 1'b0));
-  assign _zz_181 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
-  assign _zz_182 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_183 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_184 = execute_INSTRUCTION[13];
-  assign _zz_185 = _zz_79[31 : 31];
-  assign _zz_186 = _zz_79[30 : 30];
-  assign _zz_187 = _zz_79[29 : 29];
-  assign _zz_188 = _zz_79[27 : 27];
-  assign _zz_189 = _zz_79[24 : 24];
-  assign _zz_190 = _zz_79[15 : 15];
-  assign _zz_191 = _zz_79[11 : 11];
-  assign _zz_192 = _zz_79[10 : 10];
-  assign _zz_193 = _zz_79[9 : 9];
-  assign _zz_194 = _zz_79[12 : 12];
-  assign _zz_195 = _zz_79[5 : 5];
-  assign _zz_196 = _zz_79[3 : 3];
-  assign _zz_197 = _zz_79[18 : 18];
-  assign _zz_198 = _zz_79[8 : 8];
-  assign _zz_199 = _zz_79[4 : 4];
-  assign _zz_200 = _zz_79[0 : 0];
-  assign _zz_201 = (_zz_58 - 3'b001);
-  assign _zz_202 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_203 = {29'd0, _zz_202};
-  assign _zz_204 = execute_SRC_LESS;
-  assign _zz_205 = 3'b100;
-  assign _zz_206 = execute_INSTRUCTION[19 : 15];
-  assign _zz_207 = execute_INSTRUCTION[31 : 20];
-  assign _zz_208 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_209 = ($signed(_zz_210) + $signed(_zz_213));
-  assign _zz_210 = ($signed(_zz_211) + $signed(_zz_212));
-  assign _zz_211 = execute_SRC1;
-  assign _zz_212 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_213 = (execute_SRC_USE_SUB_LESS ? _zz_214 : _zz_215);
-  assign _zz_214 = 32'h00000001;
-  assign _zz_215 = 32'h0;
-  assign _zz_216 = (_zz_217 >>> 1);
-  assign _zz_217 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_218 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_219 = execute_INSTRUCTION[31 : 20];
-  assign _zz_220 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_221 = (_zz_121 & (~ _zz_222));
-  assign _zz_222 = (_zz_121 - 2'b01);
-  assign _zz_223 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_224 = execute_INSTRUCTION[31 : 24];
-  assign _zz_225 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_226 = {5'd0, _zz_225};
-  assign _zz_227 = (_zz_229 + _zz_231);
-  assign _zz_228 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_229 = {{1{_zz_228[32]}}, _zz_228};
-  assign _zz_230 = _zz_232;
-  assign _zz_231 = {{1{_zz_230[32]}}, _zz_230};
-  assign _zz_232 = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_233 = _zz_127;
-  assign _zz_234 = {32'd0, _zz_233};
-  assign _zz_235 = _zz_126;
-  assign _zz_236 = {31'd0, _zz_235};
-  assign _zz_237 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_238 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_155 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_156 = ((_zz_148 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_157 = ((_zz_148 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_158 = ({CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_159 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_160 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_161 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_162 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign _zz_163 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_164 = (1'b1 || (! 1'b1));
+  assign _zz_165 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_166 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_167 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_168 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_169 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_170 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_171 = execute_INSTRUCTION[13 : 12];
+  assign _zz_172 = (iBus_cmd_valid || (_zz_140 != 3'b000));
+  assign _zz_173 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_174 = ((_zz_120 && 1'b1) && (! 1'b0));
+  assign _zz_175 = ((_zz_121 && 1'b1) && (! 1'b0));
+  assign _zz_176 = ((_zz_122 && 1'b1) && (! 1'b0));
+  assign _zz_177 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  assign _zz_178 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_179 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_180 = execute_INSTRUCTION[13];
+  assign _zz_181 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_182 = ($signed(_zz_183) + $signed(_zz_188));
+  assign _zz_183 = ($signed(_zz_184) + $signed(_zz_186));
+  assign _zz_184 = 52'h0;
+  assign _zz_185 = {1'b0,memory_MUL_LL};
+  assign _zz_186 = {{19{_zz_185[32]}}, _zz_185};
+  assign _zz_187 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_188 = {{2{_zz_187[49]}}, _zz_187};
+  assign _zz_189 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_190 = {{2{_zz_189[49]}}, _zz_189};
+  assign _zz_191 = ($signed(_zz_193) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_192 = _zz_191[31 : 0];
+  assign _zz_193 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_194 = _zz_82[29 : 29];
+  assign _zz_195 = _zz_82[27 : 27];
+  assign _zz_196 = _zz_82[24 : 24];
+  assign _zz_197 = _zz_82[15 : 15];
+  assign _zz_198 = _zz_82[11 : 11];
+  assign _zz_199 = _zz_82[10 : 10];
+  assign _zz_200 = _zz_82[9 : 9];
+  assign _zz_201 = _zz_82[12 : 12];
+  assign _zz_202 = _zz_82[5 : 5];
+  assign _zz_203 = _zz_82[3 : 3];
+  assign _zz_204 = _zz_82[18 : 18];
+  assign _zz_205 = _zz_82[8 : 8];
+  assign _zz_206 = _zz_82[4 : 4];
+  assign _zz_207 = _zz_82[0 : 0];
+  assign _zz_208 = (_zz_61 - 3'b001);
+  assign _zz_209 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_210 = {29'd0, _zz_209};
+  assign _zz_211 = execute_SRC_LESS;
+  assign _zz_212 = 3'b100;
+  assign _zz_213 = execute_INSTRUCTION[19 : 15];
+  assign _zz_214 = execute_INSTRUCTION[31 : 20];
+  assign _zz_215 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_216 = ($signed(_zz_217) + $signed(_zz_220));
+  assign _zz_217 = ($signed(_zz_218) + $signed(_zz_219));
+  assign _zz_218 = execute_SRC1;
+  assign _zz_219 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_220 = (execute_SRC_USE_SUB_LESS ? _zz_221 : _zz_222);
+  assign _zz_221 = 32'h00000001;
+  assign _zz_222 = 32'h0;
+  assign _zz_223 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_224 = execute_INSTRUCTION[31 : 20];
+  assign _zz_225 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_226 = (_zz_123 & (~ _zz_227));
+  assign _zz_227 = (_zz_123 - 2'b01);
+  assign _zz_228 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_229 = execute_INSTRUCTION[31 : 24];
+  assign _zz_230 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_231 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_232 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_233 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_234 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_235 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_236 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_237 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_238 = execute_CsrPlugin_writeData[7 : 7];
   assign _zz_239 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_240 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_241 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_242 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_243 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_244 = 1'b1;
-  assign _zz_245 = 1'b1;
-  assign _zz_246 = {_zz_61,_zz_60};
-  assign _zz_247 = 32'h0000106f;
-  assign _zz_248 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_249 = 32'h00001073;
-  assign _zz_250 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_251 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_252 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_253) == 32'h00000003),{(_zz_254 == _zz_255),{_zz_256,{_zz_257,_zz_258}}}}}};
-  assign _zz_253 = 32'h0000207f;
-  assign _zz_254 = (decode_INSTRUCTION & 32'h0000505f);
-  assign _zz_255 = 32'h00000003;
-  assign _zz_256 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
-  assign _zz_257 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_258 = {((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033),{((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & _zz_259) == 32'h00005013),{(_zz_260 == _zz_261),{_zz_262,{_zz_263,_zz_264}}}}}};
-  assign _zz_259 = 32'hbc00707f;
-  assign _zz_260 = (decode_INSTRUCTION & 32'hfc00705f);
-  assign _zz_261 = 32'h00001013;
-  assign _zz_262 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_263 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_264 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
-  assign _zz_265 = (decode_INSTRUCTION & 32'h02000074);
-  assign _zz_266 = 32'h02000030;
-  assign _zz_267 = _zz_84;
-  assign _zz_268 = 1'b0;
-  assign _zz_269 = (((decode_INSTRUCTION & 32'h10003050) == 32'h00000050) != 1'b0);
-  assign _zz_270 = (((decode_INSTRUCTION & _zz_272) == 32'h10000050) != 1'b0);
-  assign _zz_271 = {({_zz_273,_zz_274} != 2'b00),{({_zz_275,_zz_276} != 2'b00),{(_zz_277 != _zz_278),{_zz_279,{_zz_280,_zz_281}}}}};
-  assign _zz_272 = 32'h10403050;
-  assign _zz_273 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_274 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_275 = _zz_83;
-  assign _zz_276 = ((decode_INSTRUCTION & _zz_282) == 32'h00000004);
-  assign _zz_277 = ((decode_INSTRUCTION & _zz_283) == 32'h00000040);
-  assign _zz_278 = 1'b0;
-  assign _zz_279 = ({_zz_284,_zz_285} != 2'b00);
-  assign _zz_280 = (_zz_286 != 1'b0);
-  assign _zz_281 = {(_zz_287 != _zz_288),{_zz_289,{_zz_290,_zz_291}}};
-  assign _zz_282 = 32'h0000001c;
-  assign _zz_283 = 32'h00000058;
-  assign _zz_284 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_285 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz_286 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
-  assign _zz_287 = {(_zz_292 == _zz_293),{_zz_294,_zz_295}};
-  assign _zz_288 = 3'b000;
-  assign _zz_289 = ({_zz_296,{_zz_297,_zz_298}} != 3'b000);
-  assign _zz_290 = (_zz_299 != 1'b0);
-  assign _zz_291 = {(_zz_300 != _zz_301),{_zz_302,{_zz_303,_zz_304}}};
-  assign _zz_292 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_293 = 32'h40001010;
-  assign _zz_294 = ((decode_INSTRUCTION & _zz_305) == 32'h00001010);
-  assign _zz_295 = ((decode_INSTRUCTION & _zz_306) == 32'h00001010);
-  assign _zz_296 = ((decode_INSTRUCTION & _zz_307) == 32'h00000024);
-  assign _zz_297 = (_zz_308 == _zz_309);
-  assign _zz_298 = (_zz_310 == _zz_311);
-  assign _zz_299 = ((decode_INSTRUCTION & _zz_312) == 32'h00001000);
-  assign _zz_300 = _zz_85;
-  assign _zz_301 = 1'b0;
-  assign _zz_302 = ({_zz_313,_zz_314} != 2'b00);
-  assign _zz_303 = (_zz_315 != _zz_316);
-  assign _zz_304 = {_zz_317,{_zz_318,_zz_319}};
-  assign _zz_305 = 32'h00007034;
-  assign _zz_306 = 32'h02007054;
-  assign _zz_307 = 32'h00000064;
-  assign _zz_308 = (decode_INSTRUCTION & 32'h00003034);
-  assign _zz_309 = 32'h00001010;
-  assign _zz_310 = (decode_INSTRUCTION & 32'h02003054);
-  assign _zz_311 = 32'h00001010;
-  assign _zz_312 = 32'h00001000;
-  assign _zz_313 = ((decode_INSTRUCTION & _zz_320) == 32'h00002000);
-  assign _zz_314 = ((decode_INSTRUCTION & _zz_321) == 32'h00001000);
-  assign _zz_315 = {(_zz_322 == _zz_323),(_zz_324 == _zz_325)};
-  assign _zz_316 = 2'b00;
-  assign _zz_317 = (_zz_81 != 1'b0);
-  assign _zz_318 = ({_zz_326,_zz_327} != 3'b000);
-  assign _zz_319 = {(_zz_328 != _zz_329),{_zz_330,{_zz_331,_zz_332}}};
-  assign _zz_320 = 32'h00002010;
-  assign _zz_321 = 32'h00005000;
-  assign _zz_322 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_323 = 32'h00006000;
-  assign _zz_324 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_325 = 32'h00004000;
-  assign _zz_326 = _zz_84;
-  assign _zz_327 = {(_zz_333 == _zz_334),(_zz_335 == _zz_336)};
-  assign _zz_328 = ((decode_INSTRUCTION & _zz_337) == 32'h00000020);
-  assign _zz_329 = 1'b0;
-  assign _zz_330 = ({_zz_338,_zz_339} != 2'b00);
-  assign _zz_331 = ({_zz_340,_zz_341} != 3'b000);
-  assign _zz_332 = {(_zz_342 != _zz_343),{_zz_344,{_zz_345,_zz_346}}};
-  assign _zz_333 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_334 = 32'h00000020;
-  assign _zz_335 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_336 = 32'h00000020;
-  assign _zz_337 = 32'h00000020;
-  assign _zz_338 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
-  assign _zz_339 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz_340 = _zz_82;
-  assign _zz_341 = {(_zz_347 == _zz_348),(_zz_349 == _zz_350)};
-  assign _zz_342 = {_zz_83,{_zz_351,{_zz_352,_zz_353}}};
-  assign _zz_343 = 6'h0;
-  assign _zz_344 = ({_zz_82,_zz_354} != 2'b00);
-  assign _zz_345 = ({_zz_355,_zz_356} != 2'b00);
-  assign _zz_346 = {(_zz_357 != _zz_358),{_zz_359,{_zz_360,_zz_361}}};
-  assign _zz_347 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_348 = 32'h00000010;
-  assign _zz_349 = (decode_INSTRUCTION & 32'h02000060);
-  assign _zz_350 = 32'h00000020;
-  assign _zz_351 = ((decode_INSTRUCTION & _zz_362) == 32'h00001010);
-  assign _zz_352 = (_zz_363 == _zz_364);
-  assign _zz_353 = {_zz_365,{_zz_366,_zz_367}};
-  assign _zz_354 = ((decode_INSTRUCTION & _zz_368) == 32'h00000020);
-  assign _zz_355 = _zz_82;
-  assign _zz_356 = (_zz_369 == _zz_370);
-  assign _zz_357 = {_zz_371,{_zz_372,_zz_373}};
-  assign _zz_358 = 4'b0000;
-  assign _zz_359 = (_zz_374 != 1'b0);
-  assign _zz_360 = (_zz_375 != _zz_376);
-  assign _zz_361 = {_zz_377,{_zz_378,_zz_379}};
-  assign _zz_362 = 32'h00001010;
-  assign _zz_363 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_364 = 32'h00002010;
-  assign _zz_365 = ((decode_INSTRUCTION & _zz_380) == 32'h00000010);
+  assign _zz_240 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_241 = 1'b1;
+  assign _zz_242 = 1'b1;
+  assign _zz_243 = {_zz_64,_zz_63};
+  assign _zz_244 = 32'h0000106f;
+  assign _zz_245 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_246 = 32'h00001073;
+  assign _zz_247 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_248 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_249 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_250) == 32'h00000003),{(_zz_251 == _zz_252),{_zz_253,{_zz_254,_zz_255}}}}}};
+  assign _zz_250 = 32'h0000207f;
+  assign _zz_251 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_252 = 32'h00000003;
+  assign _zz_253 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_254 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_255 = {((decode_INSTRUCTION & 32'hfc00407f) == 32'h00000033),{((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033),{((decode_INSTRUCTION & _zz_256) == 32'h00005013),{(_zz_257 == _zz_258),{_zz_259,{_zz_260,_zz_261}}}}}};
+  assign _zz_256 = 32'hbc00707f;
+  assign _zz_257 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_258 = 32'h00001013;
+  assign _zz_259 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_260 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_261 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
+  assign _zz_262 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz_263 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz_264 = 1'b0;
+  assign _zz_265 = ({(_zz_268 == _zz_269),(_zz_270 == _zz_271)} != 2'b00);
+  assign _zz_266 = ({_zz_86,_zz_272} != 2'b00);
+  assign _zz_267 = {(_zz_273 != 1'b0),{(_zz_274 != _zz_275),{_zz_276,{_zz_277,_zz_278}}}};
+  assign _zz_268 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_269 = 32'h00001050;
+  assign _zz_270 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_271 = 32'h00002050;
+  assign _zz_272 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_273 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_274 = {(_zz_279 == _zz_280),(_zz_281 == _zz_282)};
+  assign _zz_275 = 2'b00;
+  assign _zz_276 = ((_zz_283 == _zz_284) != 1'b0);
+  assign _zz_277 = ({_zz_285,_zz_286} != 3'b000);
+  assign _zz_278 = {(_zz_287 != _zz_288),{_zz_289,{_zz_290,_zz_291}}};
+  assign _zz_279 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_280 = 32'h00000040;
+  assign _zz_281 = (decode_INSTRUCTION & 32'h00403040);
+  assign _zz_282 = 32'h00000040;
+  assign _zz_283 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz_284 = 32'h00005010;
+  assign _zz_285 = ((decode_INSTRUCTION & _zz_292) == 32'h40001010);
+  assign _zz_286 = {(_zz_293 == _zz_294),(_zz_295 == _zz_296)};
+  assign _zz_287 = ((decode_INSTRUCTION & _zz_297) == 32'h00000024);
+  assign _zz_288 = 1'b0;
+  assign _zz_289 = ((_zz_298 == _zz_299) != 1'b0);
+  assign _zz_290 = (_zz_300 != 1'b0);
+  assign _zz_291 = {(_zz_301 != _zz_302),{_zz_303,{_zz_304,_zz_305}}};
+  assign _zz_292 = 32'h40003054;
+  assign _zz_293 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_294 = 32'h00001010;
+  assign _zz_295 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_296 = 32'h00001010;
+  assign _zz_297 = 32'h00000064;
+  assign _zz_298 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_299 = 32'h00001000;
+  assign _zz_300 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_301 = {(_zz_306 == _zz_307),(_zz_308 == _zz_309)};
+  assign _zz_302 = 2'b00;
+  assign _zz_303 = ((_zz_310 == _zz_311) != 1'b0);
+  assign _zz_304 = (_zz_84 != 1'b0);
+  assign _zz_305 = {(_zz_312 != _zz_313),{_zz_314,{_zz_315,_zz_316}}};
+  assign _zz_306 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_307 = 32'h00002000;
+  assign _zz_308 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_309 = 32'h00001000;
+  assign _zz_310 = (decode_INSTRUCTION & 32'h00004004);
+  assign _zz_311 = 32'h00004000;
+  assign _zz_312 = {_zz_87,{(_zz_317 == _zz_318),(_zz_319 == _zz_320)}};
+  assign _zz_313 = 3'b000;
+  assign _zz_314 = (((decode_INSTRUCTION & _zz_321) == 32'h00000020) != 1'b0);
+  assign _zz_315 = ({_zz_322,{_zz_323,_zz_324}} != 5'h0);
+  assign _zz_316 = {({_zz_325,_zz_326} != 5'h0),{(_zz_327 != _zz_328),{_zz_329,{_zz_330,_zz_331}}}};
+  assign _zz_317 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_318 = 32'h00000020;
+  assign _zz_319 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_320 = 32'h00000020;
+  assign _zz_321 = 32'h00000020;
+  assign _zz_322 = ((decode_INSTRUCTION & _zz_332) == 32'h00000008);
+  assign _zz_323 = (_zz_333 == _zz_334);
+  assign _zz_324 = {_zz_85,{_zz_335,_zz_336}};
+  assign _zz_325 = _zz_85;
+  assign _zz_326 = {_zz_337,{_zz_338,_zz_339}};
+  assign _zz_327 = {_zz_86,{_zz_340,_zz_341}};
+  assign _zz_328 = 6'h0;
+  assign _zz_329 = ({_zz_342,_zz_343} != 2'b00);
+  assign _zz_330 = (_zz_344 != _zz_345);
+  assign _zz_331 = {_zz_346,{_zz_347,_zz_348}};
+  assign _zz_332 = 32'h00000008;
+  assign _zz_333 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_334 = 32'h00000040;
+  assign _zz_335 = (_zz_349 == _zz_350);
+  assign _zz_336 = (_zz_351 == _zz_352);
+  assign _zz_337 = ((decode_INSTRUCTION & _zz_353) == 32'h00002010);
+  assign _zz_338 = (_zz_354 == _zz_355);
+  assign _zz_339 = {_zz_356,_zz_357};
+  assign _zz_340 = (_zz_358 == _zz_359);
+  assign _zz_341 = {_zz_360,{_zz_361,_zz_362}};
+  assign _zz_342 = _zz_85;
+  assign _zz_343 = (_zz_363 == _zz_364);
+  assign _zz_344 = {_zz_85,_zz_365};
+  assign _zz_345 = 2'b00;
+  assign _zz_346 = ({_zz_366,_zz_367} != 4'b0000);
+  assign _zz_347 = (_zz_368 != _zz_369);
+  assign _zz_348 = {_zz_370,{_zz_371,_zz_372}};
+  assign _zz_349 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_350 = 32'h00000010;
+  assign _zz_351 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz_352 = 32'h00000020;
+  assign _zz_353 = 32'h00002030;
+  assign _zz_354 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_355 = 32'h00000010;
+  assign _zz_356 = ((decode_INSTRUCTION & _zz_373) == 32'h00002020);
+  assign _zz_357 = ((decode_INSTRUCTION & _zz_374) == 32'h00000020);
+  assign _zz_358 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_359 = 32'h00001010;
+  assign _zz_360 = ((decode_INSTRUCTION & _zz_375) == 32'h00002010);
+  assign _zz_361 = (_zz_376 == _zz_377);
+  assign _zz_362 = {_zz_378,_zz_379};
+  assign _zz_363 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_364 = 32'h00000020;
+  assign _zz_365 = ((decode_INSTRUCTION & _zz_380) == 32'h0);
   assign _zz_366 = (_zz_381 == _zz_382);
-  assign _zz_367 = (_zz_383 == _zz_384);
-  assign _zz_368 = 32'h00000070;
-  assign _zz_369 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_370 = 32'h0;
-  assign _zz_371 = ((decode_INSTRUCTION & _zz_385) == 32'h0);
-  assign _zz_372 = (_zz_386 == _zz_387);
-  assign _zz_373 = {_zz_81,_zz_388};
-  assign _zz_374 = ((decode_INSTRUCTION & _zz_389) == 32'h0);
-  assign _zz_375 = {_zz_390,{_zz_391,_zz_392}};
-  assign _zz_376 = 3'b000;
-  assign _zz_377 = ({_zz_393,_zz_394} != 2'b00);
-  assign _zz_378 = (_zz_395 != _zz_396);
-  assign _zz_379 = (_zz_397 != _zz_398);
-  assign _zz_380 = 32'h00000050;
-  assign _zz_381 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_382 = 32'h00000004;
-  assign _zz_383 = (decode_INSTRUCTION & 32'h00000024);
-  assign _zz_384 = 32'h0;
-  assign _zz_385 = 32'h00000044;
-  assign _zz_386 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_367 = {_zz_383,{_zz_384,_zz_385}};
+  assign _zz_368 = (_zz_386 == _zz_387);
+  assign _zz_369 = 1'b0;
+  assign _zz_370 = ({_zz_388,_zz_389} != 3'b000);
+  assign _zz_371 = (_zz_390 != _zz_391);
+  assign _zz_372 = {_zz_392,_zz_393};
+  assign _zz_373 = 32'h02002060;
+  assign _zz_374 = 32'h02003020;
+  assign _zz_375 = 32'h00002010;
+  assign _zz_376 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_377 = 32'h00000010;
+  assign _zz_378 = ((decode_INSTRUCTION & _zz_394) == 32'h00000004);
+  assign _zz_379 = ((decode_INSTRUCTION & _zz_395) == 32'h0);
+  assign _zz_380 = 32'h00000020;
+  assign _zz_381 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_382 = 32'h0;
+  assign _zz_383 = ((decode_INSTRUCTION & _zz_396) == 32'h0);
+  assign _zz_384 = _zz_84;
+  assign _zz_385 = (_zz_397 == _zz_398);
+  assign _zz_386 = (decode_INSTRUCTION & 32'h00000058);
   assign _zz_387 = 32'h0;
-  assign _zz_388 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_389 = 32'h00000058;
-  assign _zz_390 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_391 = ((decode_INSTRUCTION & _zz_399) == 32'h00002010);
-  assign _zz_392 = ((decode_INSTRUCTION & _zz_400) == 32'h40000030);
-  assign _zz_393 = ((decode_INSTRUCTION & _zz_401) == 32'h00000004);
-  assign _zz_394 = _zz_80;
-  assign _zz_395 = {(_zz_402 == _zz_403),_zz_80};
-  assign _zz_396 = 2'b00;
-  assign _zz_397 = ((decode_INSTRUCTION & _zz_404) == 32'h00001004);
-  assign _zz_398 = 1'b0;
-  assign _zz_399 = 32'h00002014;
-  assign _zz_400 = 32'h40004034;
-  assign _zz_401 = 32'h00000014;
-  assign _zz_402 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_403 = 32'h00000004;
-  assign _zz_404 = 32'h00001054;
+  assign _zz_388 = (_zz_399 == _zz_400);
+  assign _zz_389 = {_zz_401,_zz_402};
+  assign _zz_390 = {_zz_403,_zz_83};
+  assign _zz_391 = 2'b00;
+  assign _zz_392 = ({_zz_404,_zz_405} != 2'b00);
+  assign _zz_393 = (_zz_406 != 1'b0);
+  assign _zz_394 = 32'h0000000c;
+  assign _zz_395 = 32'h00000024;
+  assign _zz_396 = 32'h00000018;
+  assign _zz_397 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_398 = 32'h00001000;
+  assign _zz_399 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_400 = 32'h00000040;
+  assign _zz_401 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_402 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz_403 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_404 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_405 = _zz_83;
+  assign _zz_406 = ((decode_INSTRUCTION & 32'h00001054) == 32'h00001004);
   always @ (posedge clk) begin
-    if(_zz_244) begin
-      _zz_153 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_241) begin
+      _zz_152 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_245) begin
-      _zz_154 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_242) begin
+      _zz_153 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_46) begin
+    if(_zz_49) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_144                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_145                                                     ), //i
+    .io_flush                                 (_zz_143                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_144                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_146                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_147                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_148                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_145                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_146                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_147                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1374,8 +1399,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_149                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_150                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_148                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_149                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1383,8 +1408,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_151                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_152                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_150                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_151                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1397,15 +1422,15 @@ module VexRiscv (
     .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_246)
+    case(_zz_243)
       2'b00 : begin
-        _zz_155 = CsrPlugin_jumpInterface_payload;
+        _zz_154 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_155 = DBusSimplePlugin_redoBranch_payload;
+        _zz_154 = DBusSimplePlugin_redoBranch_payload;
       end
       default : begin
-        _zz_155 = BranchPlugin_jumpInterface_payload;
+        _zz_154 = BranchPlugin_jumpInterface_payload;
       end
     endcase
   end
@@ -1540,15 +1565,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_14)
       `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
@@ -1567,12 +1583,39 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_16)
       `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
       default : _zz_16_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17_string = "SRA_1    ";
+      default : _zz_17_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_18_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_18_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_18_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_18_string = "SRA_1    ";
+      default : _zz_18_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1584,27 +1627,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
-      default : _zz_18_string = "?????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_19)
       `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
       `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
       default : _zz_19_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20_string = "AND_1";
+      default : _zz_20_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_21_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_21_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_21_string = "AND_1";
+      default : _zz_21_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1616,27 +1659,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
-      default : _zz_20_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_22)
       `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
       default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
+      default : _zz_24_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1649,30 +1692,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
-      default : _zz_23_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_24)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_24_string = "PC ";
-      default : _zz_24_string = "???";
-    endcase
-  end
-  always @(*) begin
     case(_zz_25)
       `Src2CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS ";
       `Src2CtrlEnum_defaultEncoding_IMI : _zz_25_string = "IMI";
       `Src2CtrlEnum_defaultEncoding_IMS : _zz_25_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : _zz_25_string = "PC ";
       default : _zz_25_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_26_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_26_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_26_string = "PC ";
+      default : _zz_26_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_27)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_27_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_27_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_27_string = "PC ";
+      default : _zz_27_string = "???";
     endcase
   end
   always @(*) begin
@@ -1685,30 +1728,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_27)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
-      default : _zz_27_string = "????????????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_28)
       `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
       `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
       `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
       default : _zz_28_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_29)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_29_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_29_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_29_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_29_string = "URS1        ";
+      default : _zz_29_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_30)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_30_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_30_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_30_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_30_string = "URS1        ";
+      default : _zz_30_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1719,10 +1762,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_32)
-      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
-      default : _zz_32_string = "?????";
+    case(_zz_33)
+      `Input2Kind_defaultEncoding_RS : _zz_33_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_33_string = "IMM_I";
+      default : _zz_33_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1734,11 +1777,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
-      default : _zz_33_string = "?????";
+    case(_zz_35)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
+      default : _zz_35_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1750,11 +1793,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_34_string = "ECALL";
-      default : _zz_34_string = "?????";
+    case(_zz_36)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_36_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_36_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_36_string = "ECALL";
+      default : _zz_36_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1766,11 +1809,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
-      default : _zz_35_string = "?????";
+    case(_zz_37)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_37_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_37_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_37_string = "ECALL";
+      default : _zz_37_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1783,12 +1826,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
-      default : _zz_36_string = "????";
+    case(_zz_38)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_38_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_38_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_38_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_38_string = "JALR";
+      default : _zz_38_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_40)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40_string = "SRA_1    ";
+      default : _zz_40_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1801,12 +1862,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_38_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_38_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_38_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_38_string = "SRA_1    ";
-      default : _zz_38_string = "?????????";
+    case(_zz_41)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_41_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_41_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_41_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_41_string = "SRA_1    ";
+      default : _zz_41_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1819,12 +1880,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_40_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_40_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_40_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_40_string = "PC ";
-      default : _zz_40_string = "???";
+    case(_zz_43)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_43_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_43_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_43_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_43_string = "PC ";
+      default : _zz_43_string = "???";
     endcase
   end
   always @(*) begin
@@ -1837,12 +1898,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_41)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_41_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_41_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_41_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_41_string = "URS1        ";
-      default : _zz_41_string = "????????????";
+    case(_zz_44)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_44_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_44_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_44_string = "URS1        ";
+      default : _zz_44_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1854,11 +1915,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_42_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_42_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_42_string = "BITWISE ";
-      default : _zz_42_string = "????????";
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1870,145 +1931,145 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
-      default : _zz_43_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_47)
-      `Input2Kind_defaultEncoding_RS : _zz_47_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_47_string = "IMM_I";
-      default : _zz_47_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_48)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_48_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_48_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_48_string = "ECALL";
-      default : _zz_48_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_49)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_49_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_49_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_49_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_49_string = "JALR";
-      default : _zz_49_string = "????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_50)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_50_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_50_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_50_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_50_string = "SRA_1    ";
-      default : _zz_50_string = "?????????";
+      `Input2Kind_defaultEncoding_RS : _zz_50_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_50_string = "IMM_I";
+      default : _zz_50_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_51)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_51_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_51_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_51_string = "AND_1";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_51_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_51_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_51_string = "ECALL";
       default : _zz_51_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_52)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_52_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_52_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_52_string = "BITWISE ";
-      default : _zz_52_string = "????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
+      default : _zz_52_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_53)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_53_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_53_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_53_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_53_string = "PC ";
-      default : _zz_53_string = "???";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_53_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_53_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_53_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_53_string = "SRA_1    ";
+      default : _zz_53_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_54)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_54_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_54_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_54_string = "URS1        ";
-      default : _zz_54_string = "????????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_54_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_54_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_54_string = "AND_1";
+      default : _zz_54_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_87)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_87_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_87_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_87_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_87_string = "URS1        ";
-      default : _zz_87_string = "????????????";
+    case(_zz_55)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_55_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_55_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_55_string = "BITWISE ";
+      default : _zz_55_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_56)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_56_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_56_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_56_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_56_string = "PC ";
+      default : _zz_56_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_57)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_57_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_57_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_57_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_57_string = "URS1        ";
+      default : _zz_57_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_88)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_88_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_88_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_88_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_88_string = "PC ";
-      default : _zz_88_string = "???";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_88_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_88_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_88_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_88_string = "URS1        ";
+      default : _zz_88_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_89)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_89_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_89_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_89_string = "BITWISE ";
-      default : _zz_89_string = "????????";
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_89_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_89_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_89_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_89_string = "PC ";
+      default : _zz_89_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_90)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_90_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_90_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_90_string = "AND_1";
-      default : _zz_90_string = "?????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_90_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_90_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_90_string = "BITWISE ";
+      default : _zz_90_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_91)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_91_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_91_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_91_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_91_string = "SRA_1    ";
-      default : _zz_91_string = "?????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_91_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_91_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_91_string = "AND_1";
+      default : _zz_91_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_92)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_92_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_92_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_92_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_92_string = "JALR";
-      default : _zz_92_string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_92_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_92_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_92_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_92_string = "SRA_1    ";
+      default : _zz_92_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_93)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_93_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_93_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_93_string = "ECALL";
-      default : _zz_93_string = "?????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_93_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_93_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_93_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_93_string = "JALR";
+      default : _zz_93_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_94)
-      `Input2Kind_defaultEncoding_RS : _zz_94_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_94_string = "IMM_I";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_94_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_94_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_94_string = "ECALL";
       default : _zz_94_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_95)
+      `Input2Kind_defaultEncoding_RS : _zz_95_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_95_string = "IMM_I";
+      default : _zz_95_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2055,6 +2116,15 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
       `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
@@ -2096,11 +2166,18 @@ module VexRiscv (
   end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_182) + $signed(_zz_190));
   assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
+  assign execute_SHIFT_RIGHT = _zz_192;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_96;
+  assign execute_REGFILE_WRITE_DATA = _zz_97;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
@@ -2108,136 +2185,157 @@ module VexRiscv (
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign decode_IS_RS2_SIGNED = _zz_185[0];
-  assign decode_IS_RS1_SIGNED = _zz_186[0];
-  assign decode_IS_MUL = _zz_187[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_194[0];
   assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
   assign _zz_2 = _zz_3;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_188[0];
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_195[0];
   assign _zz_4 = _zz_5;
   assign _zz_6 = _zz_7;
   assign decode_ENV_CTRL = _zz_8;
   assign _zz_9 = _zz_10;
-  assign decode_IS_CSR = _zz_189[0];
+  assign decode_IS_CSR = _zz_196[0];
   assign decode_BRANCH_CTRL = _zz_11;
   assign _zz_12 = _zz_13;
-  assign decode_SHIFT_CTRL = _zz_14;
-  assign _zz_15 = _zz_16;
-  assign decode_ALU_BITWISE_CTRL = _zz_17;
-  assign _zz_18 = _zz_19;
-  assign decode_SRC_LESS_UNSIGNED = _zz_190[0];
-  assign decode_ALU_CTRL = _zz_20;
-  assign _zz_21 = _zz_22;
-  assign decode_MEMORY_STORE = _zz_191[0];
+  assign _zz_14 = _zz_15;
+  assign decode_SHIFT_CTRL = _zz_16;
+  assign _zz_17 = _zz_18;
+  assign decode_ALU_BITWISE_CTRL = _zz_19;
+  assign _zz_20 = _zz_21;
+  assign decode_SRC_LESS_UNSIGNED = _zz_197[0];
+  assign decode_ALU_CTRL = _zz_22;
+  assign _zz_23 = _zz_24;
+  assign decode_MEMORY_STORE = _zz_198[0];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_192[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_193[0];
-  assign decode_SRC2_CTRL = _zz_23;
-  assign _zz_24 = _zz_25;
-  assign decode_SRC1_CTRL = _zz_26;
-  assign _zz_27 = _zz_28;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_199[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_200[0];
+  assign decode_SRC2_CTRL = _zz_25;
+  assign _zz_26 = _zz_27;
+  assign decode_SRC1_CTRL = _zz_28;
+  assign _zz_29 = _zz_30;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign writeBack_IS_MUL = memory_to_writeBack_IS_MUL;
+  assign writeBack_MUL_HH = memory_to_writeBack_MUL_HH;
+  assign writeBack_MUL_LOW = memory_to_writeBack_MUL_LOW;
+  assign memory_MUL_HL = execute_to_memory_MUL_HL;
+  assign memory_MUL_LH = execute_to_memory_MUL_LH;
+  assign memory_MUL_LL = execute_to_memory_MUL_LL;
   always @ (*) begin
-    _zz_29 = memory_CfuPlugin_CFU_IN_FLIGHT;
+    _zz_31 = memory_CfuPlugin_CFU_IN_FLIGHT;
     if(memory_arbitration_isStuck)begin
-      _zz_29 = 1'b0;
+      _zz_31 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_30 = execute_CfuPlugin_CFU_IN_FLIGHT;
+    _zz_32 = execute_CfuPlugin_CFU_IN_FLIGHT;
     if(execute_arbitration_isStuck)begin
-      _zz_30 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_31 = memory_REGFILE_WRITE_DATA;
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      _zz_31 = memory_CfuPlugin_rsp_payload_outputs_0;
-    end
-    if(_zz_156)begin
-      _zz_31 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+      _zz_32 = 1'b0;
     end
   end
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
-  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_33;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  always @ (*) begin
+    _zz_34 = execute_REGFILE_WRITE_DATA;
+    if(_zz_155)begin
+      _zz_34 = execute_CsrPlugin_readData;
+    end
+  end
+
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_33;
-  assign execute_ENV_CTRL = _zz_34;
-  assign writeBack_ENV_CTRL = _zz_35;
+  assign memory_ENV_CTRL = _zz_35;
+  assign execute_ENV_CTRL = _zz_36;
+  assign writeBack_ENV_CTRL = _zz_37;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_110;
+  assign execute_BRANCH_DO = _zz_112;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_36;
-  assign decode_RS2_USE = _zz_194[0];
-  assign decode_RS1_USE = _zz_195[0];
+  assign execute_BRANCH_CTRL = _zz_38;
+  assign decode_RS2_USE = _zz_201[0];
+  assign decode_RS1_USE = _zz_202[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
+  assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_37 = execute_REGFILE_WRITE_DATA;
-    if(_zz_157)begin
-      _zz_37 = _zz_103;
+    _zz_39 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid)begin
+      case(memory_SHIFT_CTRL)
+        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
+          _zz_39 = _zz_105;
+        end
+        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
+          _zz_39 = memory_SHIFT_RIGHT;
+        end
+        default : begin
+        end
+      endcase
     end
-    if(_zz_158)begin
-      _zz_37 = execute_CsrPlugin_readData;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      _zz_39 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_38;
+  assign memory_SHIFT_CTRL = _zz_40;
+  assign execute_SHIFT_CTRL = _zz_41;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_39 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_40;
-  assign execute_SRC1_CTRL = _zz_41;
-  assign decode_SRC_USE_SUB_LESS = _zz_196[0];
-  assign decode_SRC_ADD_ZERO = _zz_197[0];
+  assign _zz_42 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_43;
+  assign execute_SRC1_CTRL = _zz_44;
+  assign decode_SRC_USE_SUB_LESS = _zz_203[0];
+  assign decode_SRC_ADD_ZERO = _zz_204[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_42;
-  assign execute_SRC2 = _zz_102;
-  assign execute_SRC1 = _zz_97;
-  assign execute_ALU_BITWISE_CTRL = _zz_43;
-  assign _zz_44 = writeBack_INSTRUCTION;
-  assign _zz_45 = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_45;
+  assign execute_SRC2 = _zz_103;
+  assign execute_SRC1 = _zz_98;
+  assign execute_ALU_BITWISE_CTRL = _zz_46;
+  assign _zz_47 = writeBack_INSTRUCTION;
+  assign _zz_48 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_46 = 1'b0;
+    _zz_49 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_46 = 1'b1;
+      _zz_49 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_198[0];
+    decode_REGFILE_WRITE_VALID = _zz_205[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_247) == 32'h00000003),{(_zz_248 == _zz_249),{_zz_250,{_zz_251,_zz_252}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_244) == 32'h00000003),{(_zz_245 == _zz_246),{_zz_247,{_zz_248,_zz_249}}}}}}} != 22'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_55 = writeBack_REGFILE_WRITE_DATA;
+    _zz_58 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_55 = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_58 = writeBack_DBusSimplePlugin_rspFormated;
+    end
+    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
+      case(_zz_181)
+        2'b00 : begin
+          _zz_58 = _zz_232;
+        end
+        default : begin
+          _zz_58 = _zz_233;
+        end
+      endcase
     end
   end
 
@@ -2274,34 +2372,34 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = 1'b0;
-  assign decode_MEMORY_ENABLE = _zz_199[0];
-  assign decode_FLUSH_ALL = _zz_200[0];
+  assign decode_MEMORY_ENABLE = _zz_206[0];
+  assign decode_FLUSH_ALL = _zz_207[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_159)begin
+    if(_zz_156)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_160)begin
+    if(_zz_157)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_56 = execute_FORMAL_PC_NEXT;
+    _zz_59 = execute_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_56 = BranchPlugin_jumpInterface_payload;
+      _zz_59 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_57 = memory_FORMAL_PC_NEXT;
+    _zz_60 = memory_FORMAL_PC_NEXT;
     if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_57 = DBusSimplePlugin_redoBranch_payload;
+      _zz_60 = DBusSimplePlugin_redoBranch_payload;
     end
   end
 
@@ -2317,7 +2415,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_104 || _zz_105)))begin
+    if((decode_arbitration_isValid && (_zz_106 || _zz_107)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
@@ -2348,15 +2446,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_72)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_75)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_157)begin
-      if((! execute_LightShifterPlugin_done))begin
-        execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(_zz_158)begin
+    if(_zz_155)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2398,20 +2491,12 @@ module VexRiscv (
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_156)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
-        memory_arbitration_haltItself = 1'b1;
-      end
-      if(_zz_161)begin
-        memory_arbitration_haltItself = 1'b1;
-      end
-    end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_162)begin
+    if(_zz_158)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2431,7 +2516,7 @@ module VexRiscv (
     if(DBusSimplePlugin_redoBranch_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_162)begin
+    if(_zz_158)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2448,10 +2533,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_163)begin
+    if(_zz_159)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_164)begin
+    if(_zz_160)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2465,10 +2550,10 @@ module VexRiscv (
     if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_163)begin
+    if(_zz_159)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_164)begin
+    if(_zz_160)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2484,21 +2569,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_163)begin
+    if(_zz_159)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_164)begin
+    if(_zz_160)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_163)begin
+    if(_zz_159)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_164)begin
-      case(_zz_165)
+    if(_zz_160)begin
+      case(_zz_161)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2513,11 +2598,11 @@ module VexRiscv (
   assign CsrPlugin_allowException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != 3'b000);
-  assign _zz_58 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_59 = (_zz_58 & (~ _zz_201));
-  assign _zz_60 = _zz_59[1];
-  assign _zz_61 = _zz_59[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_155;
+  assign _zz_61 = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_62 = (_zz_61 & (~ _zz_208));
+  assign _zz_63 = _zz_62[1];
+  assign _zz_64 = _zz_62[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_154;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -2537,7 +2622,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_203);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_210);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -2577,9 +2662,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62);
+  assign _zz_65 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_65);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_65);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -2588,9 +2673,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63);
+  assign _zz_66 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_66);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_66);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -2599,22 +2684,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64);
+  assign _zz_67 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_67);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_67);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65;
-  assign _zz_65 = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_68;
+  assign _zz_68 = ((1'b0 && (! _zz_69)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_69 = _zz_70;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_69;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_68 = _zz_69;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_71)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_71 = _zz_72;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_71;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_73;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -2636,33 +2721,33 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_145 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_146 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_147 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_146;
+  assign _zz_144 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_145 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_146 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_145;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_149 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_150 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_151 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_148 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_149 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_150 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_160)begin
+    if(_zz_157)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_159)begin
+    if(_zz_156)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_152 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_159)begin
-      _zz_152 = 1'b1;
+    _zz_151 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_156)begin
+      _zz_151 = 1'b1;
     end
   end
 
@@ -2670,8 +2755,8 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_144 = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_72 = 1'b0;
+  assign _zz_143 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_75 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
@@ -2682,39 +2767,39 @@ module VexRiscv (
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_72));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_75));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_73 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_76 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_73 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_76 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_73 = execute_RS2[31 : 0];
+        _zz_76 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_73;
+  assign dBus_cmd_payload_data = _zz_76;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_74 = 4'b0001;
+        _zz_77 = 4'b0001;
       end
       2'b01 : begin
-        _zz_74 = 4'b0011;
+        _zz_77 = 4'b0011;
       end
       default : begin
-        _zz_74 = 4'b1111;
+        _zz_77 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_74 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_77 <<< dBus_cmd_payload_address[1 : 0]);
   assign DBusSimplePlugin_mmuBus_cmd_0_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign DBusSimplePlugin_mmuBus_cmd_0_isStuck = execute_arbitration_isStuck;
   assign DBusSimplePlugin_mmuBus_cmd_0_virtualAddress = execute_SRC_ADD;
@@ -2730,7 +2815,7 @@ module VexRiscv (
         DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
       end
     end
-    if(_zz_166)begin
+    if(_zz_162)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
@@ -2750,7 +2835,7 @@ module VexRiscv (
     if(memory_MMU_RSP2_refilling)begin
       DBusSimplePlugin_redoBranch_valid = 1'b1;
     end
-    if(_zz_166)begin
+    if(_zz_162)begin
       DBusSimplePlugin_redoBranch_valid = 1'b0;
     end
   end
@@ -2773,63 +2858,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_75 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_78 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_76[31] = _zz_75;
-    _zz_76[30] = _zz_75;
-    _zz_76[29] = _zz_75;
-    _zz_76[28] = _zz_75;
-    _zz_76[27] = _zz_75;
-    _zz_76[26] = _zz_75;
-    _zz_76[25] = _zz_75;
-    _zz_76[24] = _zz_75;
-    _zz_76[23] = _zz_75;
-    _zz_76[22] = _zz_75;
-    _zz_76[21] = _zz_75;
-    _zz_76[20] = _zz_75;
-    _zz_76[19] = _zz_75;
-    _zz_76[18] = _zz_75;
-    _zz_76[17] = _zz_75;
-    _zz_76[16] = _zz_75;
-    _zz_76[15] = _zz_75;
-    _zz_76[14] = _zz_75;
-    _zz_76[13] = _zz_75;
-    _zz_76[12] = _zz_75;
-    _zz_76[11] = _zz_75;
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_79[31] = _zz_78;
+    _zz_79[30] = _zz_78;
+    _zz_79[29] = _zz_78;
+    _zz_79[28] = _zz_78;
+    _zz_79[27] = _zz_78;
+    _zz_79[26] = _zz_78;
+    _zz_79[25] = _zz_78;
+    _zz_79[24] = _zz_78;
+    _zz_79[23] = _zz_78;
+    _zz_79[22] = _zz_78;
+    _zz_79[21] = _zz_78;
+    _zz_79[20] = _zz_78;
+    _zz_79[19] = _zz_78;
+    _zz_79[18] = _zz_78;
+    _zz_79[17] = _zz_78;
+    _zz_79[16] = _zz_78;
+    _zz_79[15] = _zz_78;
+    _zz_79[14] = _zz_78;
+    _zz_79[13] = _zz_78;
+    _zz_79[12] = _zz_78;
+    _zz_79[11] = _zz_78;
+    _zz_79[10] = _zz_78;
+    _zz_79[9] = _zz_78;
+    _zz_79[8] = _zz_78;
+    _zz_79[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_77 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_80 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_78[31] = _zz_77;
-    _zz_78[30] = _zz_77;
-    _zz_78[29] = _zz_77;
-    _zz_78[28] = _zz_77;
-    _zz_78[27] = _zz_77;
-    _zz_78[26] = _zz_77;
-    _zz_78[25] = _zz_77;
-    _zz_78[24] = _zz_77;
-    _zz_78[23] = _zz_77;
-    _zz_78[22] = _zz_77;
-    _zz_78[21] = _zz_77;
-    _zz_78[20] = _zz_77;
-    _zz_78[19] = _zz_77;
-    _zz_78[18] = _zz_77;
-    _zz_78[17] = _zz_77;
-    _zz_78[16] = _zz_77;
-    _zz_78[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_81[31] = _zz_80;
+    _zz_81[30] = _zz_80;
+    _zz_81[29] = _zz_80;
+    _zz_81[28] = _zz_80;
+    _zz_81[27] = _zz_80;
+    _zz_81[26] = _zz_80;
+    _zz_81[25] = _zz_80;
+    _zz_81[24] = _zz_80;
+    _zz_81[23] = _zz_80;
+    _zz_81[22] = _zz_80;
+    _zz_81[21] = _zz_80;
+    _zz_81[20] = _zz_80;
+    _zz_81[19] = _zz_80;
+    _zz_81[18] = _zz_80;
+    _zz_81[17] = _zz_80;
+    _zz_81[16] = _zz_80;
+    _zz_81[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_183)
+    case(_zz_179)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_76;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_79;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_78;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_81;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2855,54 +2940,52 @@ module VexRiscv (
   assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_80 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_81 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_82 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_83 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_84 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_85 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_86 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00001000);
-  assign _zz_79 = {(_zz_86 != 1'b0),{({_zz_86,_zz_85} != 2'b00),{((_zz_265 == _zz_266) != 1'b0),{1'b0,{(_zz_267 != _zz_268),{_zz_269,{_zz_270,_zz_271}}}}}}};
-  assign _zz_87 = _zz_79[2 : 1];
-  assign _zz_54 = _zz_87;
-  assign _zz_88 = _zz_79[7 : 6];
-  assign _zz_53 = _zz_88;
-  assign _zz_89 = _zz_79[14 : 13];
-  assign _zz_52 = _zz_89;
-  assign _zz_90 = _zz_79[17 : 16];
-  assign _zz_51 = _zz_90;
-  assign _zz_91 = _zz_79[20 : 19];
-  assign _zz_50 = _zz_91;
-  assign _zz_92 = _zz_79[23 : 22];
-  assign _zz_49 = _zz_92;
-  assign _zz_93 = _zz_79[26 : 25];
-  assign _zz_48 = _zz_93;
-  assign _zz_94 = _zz_79[28 : 28];
-  assign _zz_47 = _zz_94;
+  assign _zz_83 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_84 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_85 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_86 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_87 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_82 = {(((decode_INSTRUCTION & 32'h02000074) == 32'h02000030) != 1'b0),{1'b0,{(_zz_87 != 1'b0),{(_zz_262 != 1'b0),{(_zz_263 != _zz_264),{_zz_265,{_zz_266,_zz_267}}}}}}};
+  assign _zz_88 = _zz_82[2 : 1];
+  assign _zz_57 = _zz_88;
+  assign _zz_89 = _zz_82[7 : 6];
+  assign _zz_56 = _zz_89;
+  assign _zz_90 = _zz_82[14 : 13];
+  assign _zz_55 = _zz_90;
+  assign _zz_91 = _zz_82[17 : 16];
+  assign _zz_54 = _zz_91;
+  assign _zz_92 = _zz_82[20 : 19];
+  assign _zz_53 = _zz_92;
+  assign _zz_93 = _zz_82[23 : 22];
+  assign _zz_52 = _zz_93;
+  assign _zz_94 = _zz_82[26 : 25];
+  assign _zz_51 = _zz_94;
+  assign _zz_95 = _zz_82[28 : 28];
+  assign _zz_50 = _zz_95;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_153;
-  assign decode_RegFilePlugin_rs2Data = _zz_154;
+  assign decode_RegFilePlugin_rs1Data = _zz_152;
+  assign decode_RegFilePlugin_rs2Data = _zz_153;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_45 && writeBack_arbitration_isFiring);
-    if(_zz_95)begin
+    lastStageRegFileWrite_valid = (_zz_48 && writeBack_arbitration_isFiring);
+    if(_zz_96)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_44[11 : 7];
-    if(_zz_95)begin
+    lastStageRegFileWrite_payload_address = _zz_47[11 : 7];
+    if(_zz_96)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_55;
-    if(_zz_95)begin
+    lastStageRegFileWrite_payload_data = _zz_58;
+    if(_zz_96)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -2924,13 +3007,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_96 = execute_IntAluPlugin_bitwise;
+        _zz_97 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_96 = {31'd0, _zz_204};
+        _zz_97 = {31'd0, _zz_211};
       end
       default : begin
-        _zz_96 = execute_SRC_ADD_SUB;
+        _zz_97 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -2938,232 +3021,265 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_97 = execute_RS1;
+        _zz_98 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_97 = {29'd0, _zz_205};
+        _zz_98 = {29'd0, _zz_212};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_97 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_98 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_97 = {27'd0, _zz_206};
+        _zz_98 = {27'd0, _zz_213};
       end
     endcase
   end
 
-  assign _zz_98 = _zz_207[11];
+  assign _zz_99 = _zz_214[11];
   always @ (*) begin
-    _zz_99[19] = _zz_98;
-    _zz_99[18] = _zz_98;
-    _zz_99[17] = _zz_98;
-    _zz_99[16] = _zz_98;
-    _zz_99[15] = _zz_98;
-    _zz_99[14] = _zz_98;
-    _zz_99[13] = _zz_98;
-    _zz_99[12] = _zz_98;
-    _zz_99[11] = _zz_98;
-    _zz_99[10] = _zz_98;
-    _zz_99[9] = _zz_98;
-    _zz_99[8] = _zz_98;
-    _zz_99[7] = _zz_98;
-    _zz_99[6] = _zz_98;
-    _zz_99[5] = _zz_98;
-    _zz_99[4] = _zz_98;
-    _zz_99[3] = _zz_98;
-    _zz_99[2] = _zz_98;
-    _zz_99[1] = _zz_98;
-    _zz_99[0] = _zz_98;
+    _zz_100[19] = _zz_99;
+    _zz_100[18] = _zz_99;
+    _zz_100[17] = _zz_99;
+    _zz_100[16] = _zz_99;
+    _zz_100[15] = _zz_99;
+    _zz_100[14] = _zz_99;
+    _zz_100[13] = _zz_99;
+    _zz_100[12] = _zz_99;
+    _zz_100[11] = _zz_99;
+    _zz_100[10] = _zz_99;
+    _zz_100[9] = _zz_99;
+    _zz_100[8] = _zz_99;
+    _zz_100[7] = _zz_99;
+    _zz_100[6] = _zz_99;
+    _zz_100[5] = _zz_99;
+    _zz_100[4] = _zz_99;
+    _zz_100[3] = _zz_99;
+    _zz_100[2] = _zz_99;
+    _zz_100[1] = _zz_99;
+    _zz_100[0] = _zz_99;
   end
 
-  assign _zz_100 = _zz_208[11];
+  assign _zz_101 = _zz_215[11];
   always @ (*) begin
-    _zz_101[19] = _zz_100;
-    _zz_101[18] = _zz_100;
-    _zz_101[17] = _zz_100;
-    _zz_101[16] = _zz_100;
-    _zz_101[15] = _zz_100;
-    _zz_101[14] = _zz_100;
-    _zz_101[13] = _zz_100;
-    _zz_101[12] = _zz_100;
-    _zz_101[11] = _zz_100;
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+    _zz_102[19] = _zz_101;
+    _zz_102[18] = _zz_101;
+    _zz_102[17] = _zz_101;
+    _zz_102[16] = _zz_101;
+    _zz_102[15] = _zz_101;
+    _zz_102[14] = _zz_101;
+    _zz_102[13] = _zz_101;
+    _zz_102[12] = _zz_101;
+    _zz_102[11] = _zz_101;
+    _zz_102[10] = _zz_101;
+    _zz_102[9] = _zz_101;
+    _zz_102[8] = _zz_101;
+    _zz_102[7] = _zz_101;
+    _zz_102[6] = _zz_101;
+    _zz_102[5] = _zz_101;
+    _zz_102[4] = _zz_101;
+    _zz_102[3] = _zz_101;
+    _zz_102[2] = _zz_101;
+    _zz_102[1] = _zz_101;
+    _zz_102[0] = _zz_101;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_102 = execute_RS2;
+        _zz_103 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
+        _zz_103 = {_zz_100,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_102 = {_zz_101,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_103 = {_zz_102,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_102 = _zz_39;
+        _zz_103 = _zz_42;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_209;
+    execute_SrcPlugin_addSub = _zz_216;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
-  assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
-  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
+  assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_103 = (execute_LightShifterPlugin_shiftInput <<< 1);
-      end
-      default : begin
-        _zz_103 = _zz_216;
-      end
-    endcase
+    _zz_104[0] = execute_SRC1[31];
+    _zz_104[1] = execute_SRC1[30];
+    _zz_104[2] = execute_SRC1[29];
+    _zz_104[3] = execute_SRC1[28];
+    _zz_104[4] = execute_SRC1[27];
+    _zz_104[5] = execute_SRC1[26];
+    _zz_104[6] = execute_SRC1[25];
+    _zz_104[7] = execute_SRC1[24];
+    _zz_104[8] = execute_SRC1[23];
+    _zz_104[9] = execute_SRC1[22];
+    _zz_104[10] = execute_SRC1[21];
+    _zz_104[11] = execute_SRC1[20];
+    _zz_104[12] = execute_SRC1[19];
+    _zz_104[13] = execute_SRC1[18];
+    _zz_104[14] = execute_SRC1[17];
+    _zz_104[15] = execute_SRC1[16];
+    _zz_104[16] = execute_SRC1[15];
+    _zz_104[17] = execute_SRC1[14];
+    _zz_104[18] = execute_SRC1[13];
+    _zz_104[19] = execute_SRC1[12];
+    _zz_104[20] = execute_SRC1[11];
+    _zz_104[21] = execute_SRC1[10];
+    _zz_104[22] = execute_SRC1[9];
+    _zz_104[23] = execute_SRC1[8];
+    _zz_104[24] = execute_SRC1[7];
+    _zz_104[25] = execute_SRC1[6];
+    _zz_104[26] = execute_SRC1[5];
+    _zz_104[27] = execute_SRC1[4];
+    _zz_104[28] = execute_SRC1[3];
+    _zz_104[29] = execute_SRC1[2];
+    _zz_104[30] = execute_SRC1[1];
+    _zz_104[31] = execute_SRC1[0];
+  end
+
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_104 : execute_SRC1);
+  always @ (*) begin
+    _zz_105[0] = memory_SHIFT_RIGHT[31];
+    _zz_105[1] = memory_SHIFT_RIGHT[30];
+    _zz_105[2] = memory_SHIFT_RIGHT[29];
+    _zz_105[3] = memory_SHIFT_RIGHT[28];
+    _zz_105[4] = memory_SHIFT_RIGHT[27];
+    _zz_105[5] = memory_SHIFT_RIGHT[26];
+    _zz_105[6] = memory_SHIFT_RIGHT[25];
+    _zz_105[7] = memory_SHIFT_RIGHT[24];
+    _zz_105[8] = memory_SHIFT_RIGHT[23];
+    _zz_105[9] = memory_SHIFT_RIGHT[22];
+    _zz_105[10] = memory_SHIFT_RIGHT[21];
+    _zz_105[11] = memory_SHIFT_RIGHT[20];
+    _zz_105[12] = memory_SHIFT_RIGHT[19];
+    _zz_105[13] = memory_SHIFT_RIGHT[18];
+    _zz_105[14] = memory_SHIFT_RIGHT[17];
+    _zz_105[15] = memory_SHIFT_RIGHT[16];
+    _zz_105[16] = memory_SHIFT_RIGHT[15];
+    _zz_105[17] = memory_SHIFT_RIGHT[14];
+    _zz_105[18] = memory_SHIFT_RIGHT[13];
+    _zz_105[19] = memory_SHIFT_RIGHT[12];
+    _zz_105[20] = memory_SHIFT_RIGHT[11];
+    _zz_105[21] = memory_SHIFT_RIGHT[10];
+    _zz_105[22] = memory_SHIFT_RIGHT[9];
+    _zz_105[23] = memory_SHIFT_RIGHT[8];
+    _zz_105[24] = memory_SHIFT_RIGHT[7];
+    _zz_105[25] = memory_SHIFT_RIGHT[6];
+    _zz_105[26] = memory_SHIFT_RIGHT[5];
+    _zz_105[27] = memory_SHIFT_RIGHT[4];
+    _zz_105[28] = memory_SHIFT_RIGHT[3];
+    _zz_105[29] = memory_SHIFT_RIGHT[2];
+    _zz_105[30] = memory_SHIFT_RIGHT[1];
+    _zz_105[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_104 = 1'b0;
-    if(_zz_106)begin
-      if((_zz_107 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_104 = 1'b1;
+    _zz_106 = 1'b0;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_106 = 1'b1;
+      end
+    end
+    if(_zz_163)begin
+      if(_zz_164)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_106 = 1'b1;
+        end
+      end
+    end
+    if(_zz_165)begin
+      if(_zz_166)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
+          _zz_106 = 1'b1;
+        end
       end
     end
     if(_zz_167)begin
       if(_zz_168)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_104 = 1'b1;
-        end
-      end
-    end
-    if(_zz_169)begin
-      if(_zz_170)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_104 = 1'b1;
-        end
-      end
-    end
-    if(_zz_171)begin
-      if(_zz_172)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_104 = 1'b1;
+          _zz_106 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_104 = 1'b0;
+      _zz_106 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_105 = 1'b0;
-    if(_zz_106)begin
-      if((_zz_107 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_105 = 1'b1;
+    _zz_107 = 1'b0;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_107 = 1'b1;
+      end
+    end
+    if(_zz_163)begin
+      if(_zz_164)begin
+        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_107 = 1'b1;
+        end
+      end
+    end
+    if(_zz_165)begin
+      if(_zz_166)begin
+        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
+          _zz_107 = 1'b1;
+        end
       end
     end
     if(_zz_167)begin
       if(_zz_168)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_105 = 1'b1;
-        end
-      end
-    end
-    if(_zz_169)begin
-      if(_zz_170)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_105 = 1'b1;
-        end
-      end
-    end
-    if(_zz_171)begin
-      if(_zz_172)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_105 = 1'b1;
+          _zz_107 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_105 = 1'b0;
+      _zz_107 = 1'b0;
     end
   end
 
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_108 = execute_INSTRUCTION[14 : 12];
+  assign _zz_110 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_108 == 3'b000)) begin
-        _zz_109 = execute_BranchPlugin_eq;
-    end else if((_zz_108 == 3'b001)) begin
-        _zz_109 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_108 & 3'b101) == 3'b101))) begin
-        _zz_109 = (! execute_SRC_LESS);
+    if((_zz_110 == 3'b000)) begin
+        _zz_111 = execute_BranchPlugin_eq;
+    end else if((_zz_110 == 3'b001)) begin
+        _zz_111 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_110 & 3'b101) == 3'b101))) begin
+        _zz_111 = (! execute_SRC_LESS);
     end else begin
-        _zz_109 = execute_SRC_LESS;
+        _zz_111 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_110 = 1'b0;
+        _zz_112 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_110 = 1'b1;
+        _zz_112 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_110 = 1'b1;
+        _zz_112 = 1'b1;
       end
       default : begin
-        _zz_110 = _zz_109;
+        _zz_112 = _zz_111;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_111 = _zz_218[19];
+  assign _zz_113 = _zz_223[19];
   always @ (*) begin
-    _zz_112[10] = _zz_111;
-    _zz_112[9] = _zz_111;
-    _zz_112[8] = _zz_111;
-    _zz_112[7] = _zz_111;
-    _zz_112[6] = _zz_111;
-    _zz_112[5] = _zz_111;
-    _zz_112[4] = _zz_111;
-    _zz_112[3] = _zz_111;
-    _zz_112[2] = _zz_111;
-    _zz_112[1] = _zz_111;
-    _zz_112[0] = _zz_111;
-  end
-
-  assign _zz_113 = _zz_219[11];
-  always @ (*) begin
-    _zz_114[19] = _zz_113;
-    _zz_114[18] = _zz_113;
-    _zz_114[17] = _zz_113;
-    _zz_114[16] = _zz_113;
-    _zz_114[15] = _zz_113;
-    _zz_114[14] = _zz_113;
-    _zz_114[13] = _zz_113;
-    _zz_114[12] = _zz_113;
-    _zz_114[11] = _zz_113;
     _zz_114[10] = _zz_113;
     _zz_114[9] = _zz_113;
     _zz_114[8] = _zz_113;
@@ -3177,8 +3293,9 @@ module VexRiscv (
     _zz_114[0] = _zz_113;
   end
 
-  assign _zz_115 = _zz_220[11];
+  assign _zz_115 = _zz_224[11];
   always @ (*) begin
+    _zz_116[19] = _zz_115;
     _zz_116[18] = _zz_115;
     _zz_116[17] = _zz_115;
     _zz_116[16] = _zz_115;
@@ -3200,21 +3317,44 @@ module VexRiscv (
     _zz_116[0] = _zz_115;
   end
 
+  assign _zz_117 = _zz_225[11];
+  always @ (*) begin
+    _zz_118[18] = _zz_117;
+    _zz_118[17] = _zz_117;
+    _zz_118[16] = _zz_117;
+    _zz_118[15] = _zz_117;
+    _zz_118[14] = _zz_117;
+    _zz_118[13] = _zz_117;
+    _zz_118[12] = _zz_117;
+    _zz_118[11] = _zz_117;
+    _zz_118[10] = _zz_117;
+    _zz_118[9] = _zz_117;
+    _zz_118[8] = _zz_117;
+    _zz_118[7] = _zz_117;
+    _zz_118[6] = _zz_117;
+    _zz_118[5] = _zz_117;
+    _zz_118[4] = _zz_117;
+    _zz_118[3] = _zz_117;
+    _zz_118[2] = _zz_117;
+    _zz_118[1] = _zz_117;
+    _zz_118[0] = _zz_117;
+  end
+
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_117 = {{_zz_112,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_119 = {{_zz_114,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_117 = {_zz_114,execute_INSTRUCTION[31 : 20]};
+        _zz_119 = {_zz_116,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_117 = {{_zz_116,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_119 = {{_zz_118,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_117;
+  assign execute_BranchPlugin_branch_src2 = _zz_119;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
@@ -3227,13 +3367,13 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_118 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_119 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_120 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_120 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_121 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_122 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_121 = {CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_122 = _zz_221[0];
+  assign _zz_123 = {CfuPlugin_joinException_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_124 = _zz_226[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
     if(decodeExceptionPort_valid)begin
@@ -3256,7 +3396,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_162)begin
+    if(_zz_158)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -3374,7 +3514,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_173)begin
+    if(_zz_169)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -3393,14 +3533,14 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_174)begin
+    if(_zz_170)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_174)begin
+    if(_zz_170)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3415,14 +3555,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_173)begin
+    if(_zz_169)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_173)begin
+    if(_zz_169)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3431,7 +3571,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_184)
+    case(_zz_180)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -3444,49 +3584,49 @@ module VexRiscv (
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign execute_CfuPlugin_functionsIds_0 = _zz_223;
+  assign execute_CfuPlugin_functionsIds_0 = _zz_228;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
-  assign _zz_123 = _zz_224[7];
+  assign _zz_125 = _zz_229[7];
   always @ (*) begin
-    _zz_124[23] = _zz_123;
-    _zz_124[22] = _zz_123;
-    _zz_124[21] = _zz_123;
-    _zz_124[20] = _zz_123;
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
+    _zz_126[23] = _zz_125;
+    _zz_126[22] = _zz_125;
+    _zz_126[21] = _zz_125;
+    _zz_126[20] = _zz_125;
+    _zz_126[19] = _zz_125;
+    _zz_126[18] = _zz_125;
+    _zz_126[17] = _zz_125;
+    _zz_126[16] = _zz_125;
+    _zz_126[15] = _zz_125;
+    _zz_126[14] = _zz_125;
+    _zz_126[13] = _zz_125;
+    _zz_126[12] = _zz_125;
+    _zz_126[11] = _zz_125;
+    _zz_126[10] = _zz_125;
+    _zz_126[9] = _zz_125;
+    _zz_126[8] = _zz_125;
+    _zz_126[7] = _zz_125;
+    _zz_126[6] = _zz_125;
+    _zz_126[5] = _zz_125;
+    _zz_126[4] = _zz_125;
+    _zz_126[3] = _zz_125;
+    _zz_126[2] = _zz_125;
+    _zz_126[1] = _zz_125;
+    _zz_126[0] = _zz_125;
   end
 
   always @ (*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
       `Input2Kind_defaultEncoding_RS : begin
-        _zz_125 = execute_RS2;
+        _zz_127 = execute_RS2;
       end
       default : begin
-        _zz_125 = {_zz_124,execute_INSTRUCTION[31 : 24]};
+        _zz_127 = {_zz_126,execute_INSTRUCTION[31 : 24]};
       end
     endcase
   end
 
-  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_125;
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_127;
   assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
   assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
@@ -3509,73 +3649,75 @@ module VexRiscv (
     end
   end
 
-  assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
+  assign execute_MulPlugin_a = execute_RS1;
+  assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_156)begin
-      if(_zz_161)begin
-        memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
+    case(_zz_171)
+      2'b01 : begin
+        execute_MulPlugin_aSigned = 1'b1;
       end
-    end
+      2'b10 : begin
+        execute_MulPlugin_aSigned = 1'b1;
+      end
+      default : begin
+        execute_MulPlugin_aSigned = 1'b0;
+      end
+    endcase
   end
 
   always @ (*) begin
-    memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! memory_arbitration_isStuck))begin
-      memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
-    end
+    case(_zz_171)
+      2'b01 : begin
+        execute_MulPlugin_bSigned = 1'b1;
+      end
+      2'b10 : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+      default : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+    endcase
   end
 
-  assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
-  assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
-    end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_226);
-    end
-    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
-    end
-  end
-
-  assign _zz_126 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_127 = ((execute_IS_MUL && _zz_126) || 1'b0);
-  always @ (*) begin
-    _zz_128[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_128[31 : 0] = execute_RS1;
-  end
-
-  assign _zz_130 = (_zz_129 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_130 != 32'h0);
-  assign _zz_28 = decode_SRC1_CTRL;
-  assign _zz_26 = _zz_54;
-  assign _zz_41 = decode_to_execute_SRC1_CTRL;
-  assign _zz_25 = decode_SRC2_CTRL;
-  assign _zz_23 = _zz_53;
-  assign _zz_40 = decode_to_execute_SRC2_CTRL;
-  assign _zz_22 = decode_ALU_CTRL;
-  assign _zz_20 = _zz_52;
-  assign _zz_42 = decode_to_execute_ALU_CTRL;
-  assign _zz_19 = decode_ALU_BITWISE_CTRL;
-  assign _zz_17 = _zz_51;
-  assign _zz_43 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_16 = decode_SHIFT_CTRL;
-  assign _zz_14 = _zz_50;
-  assign _zz_38 = decode_to_execute_SHIFT_CTRL;
+  assign execute_MulPlugin_aULow = execute_MulPlugin_a[15 : 0];
+  assign execute_MulPlugin_bULow = execute_MulPlugin_b[15 : 0];
+  assign execute_MulPlugin_aSLow = {1'b0,execute_MulPlugin_a[15 : 0]};
+  assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
+  assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
+  assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
+  assign writeBack_MulPlugin_result = ($signed(_zz_230) + $signed(_zz_231));
+  assign _zz_129 = (_zz_128 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_129 != 32'h0);
+  assign _zz_30 = decode_SRC1_CTRL;
+  assign _zz_28 = _zz_57;
+  assign _zz_44 = decode_to_execute_SRC1_CTRL;
+  assign _zz_27 = decode_SRC2_CTRL;
+  assign _zz_25 = _zz_56;
+  assign _zz_43 = decode_to_execute_SRC2_CTRL;
+  assign _zz_24 = decode_ALU_CTRL;
+  assign _zz_22 = _zz_55;
+  assign _zz_45 = decode_to_execute_ALU_CTRL;
+  assign _zz_21 = decode_ALU_BITWISE_CTRL;
+  assign _zz_19 = _zz_54;
+  assign _zz_46 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_18 = decode_SHIFT_CTRL;
+  assign _zz_15 = execute_SHIFT_CTRL;
+  assign _zz_16 = _zz_53;
+  assign _zz_41 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_40 = execute_to_memory_SHIFT_CTRL;
   assign _zz_13 = decode_BRANCH_CTRL;
-  assign _zz_11 = _zz_49;
-  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_11 = _zz_52;
+  assign _zz_38 = decode_to_execute_BRANCH_CTRL;
   assign _zz_10 = decode_ENV_CTRL;
   assign _zz_7 = execute_ENV_CTRL;
   assign _zz_5 = memory_ENV_CTRL;
-  assign _zz_8 = _zz_48;
-  assign _zz_34 = decode_to_execute_ENV_CTRL;
-  assign _zz_33 = execute_to_memory_ENV_CTRL;
-  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_8 = _zz_51;
+  assign _zz_36 = decode_to_execute_ENV_CTRL;
+  assign _zz_35 = execute_to_memory_ENV_CTRL;
+  assign _zz_37 = memory_to_writeBack_ENV_CTRL;
   assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_1 = _zz_47;
-  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_1 = _zz_50;
+  assign _zz_33 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3597,105 +3739,105 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_131 = 32'h0;
+    _zz_130 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_131[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_131[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_131[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_130[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_130[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_130[3 : 3] = CsrPlugin_mstatus_MIE;
+    end
+  end
+
+  always @ (*) begin
+    _zz_131 = 32'h0;
+    if(execute_CsrPlugin_csr_836)begin
+      _zz_131[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_131[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_131[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
     _zz_132 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_132[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_132[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_132[3 : 3] = CsrPlugin_mip_MSIP;
+    if(execute_CsrPlugin_csr_772)begin
+      _zz_132[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_132[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_132[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
     _zz_133 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_133[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_133[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_133[3 : 3] = CsrPlugin_mie_MSIE;
+    if(execute_CsrPlugin_csr_833)begin
+      _zz_133[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
     _zz_134 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_134[31 : 0] = CsrPlugin_mepc;
+    if(execute_CsrPlugin_csr_834)begin
+      _zz_134[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_134[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
     _zz_135 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_135[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_135[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    if(execute_CsrPlugin_csr_835)begin
+      _zz_135[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
     _zz_136 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_136[31 : 0] = CsrPlugin_mtval;
+    if(execute_CsrPlugin_csr_2816)begin
+      _zz_136[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
     _zz_137 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_137[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    if(execute_CsrPlugin_csr_2944)begin
+      _zz_137[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
     _zz_138 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_138[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_3008)begin
+      _zz_138[31 : 0] = _zz_128;
     end
   end
 
   always @ (*) begin
     _zz_139 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_4032)begin
       _zz_139[31 : 0] = _zz_129;
     end
   end
 
-  always @ (*) begin
-    _zz_140 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_140[31 : 0] = _zz_130;
-    end
-  end
-
-  assign execute_CsrPlugin_readData = ((((_zz_131 | _zz_132) | (_zz_133 | _zz_134)) | ((_zz_135 | _zz_136) | (_zz_137 | _zz_138))) | (_zz_139 | _zz_140));
-  assign iBusWishbone_ADR = {_zz_243,_zz_141};
-  assign iBusWishbone_CTI = ((_zz_141 == 3'b111) ? 3'b111 : 3'b010);
+  assign execute_CsrPlugin_readData = ((((_zz_130 | _zz_131) | (_zz_132 | _zz_133)) | ((_zz_134 | _zz_135) | (_zz_136 | _zz_137))) | (_zz_138 | _zz_139));
+  assign iBusWishbone_ADR = {_zz_240,_zz_140};
+  assign iBusWishbone_CTI = ((_zz_140 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_175)begin
+    if(_zz_172)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_175)begin
+    if(_zz_172)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_142;
+  assign iBus_rsp_valid = _zz_141;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -3710,19 +3852,19 @@ module VexRiscv (
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_143 = 4'b0001;
+        _zz_142 = 4'b0001;
       end
       2'b01 : begin
-        _zz_143 = 4'b0011;
+        _zz_142 = 4'b0011;
       end
       default : begin
-        _zz_143 = 4'b1111;
+        _zz_142 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_143 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_142 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
       dBusWishbone_SEL = 4'b1111;
     end
@@ -3742,18 +3884,17 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_67 <= 1'b0;
-      _zz_69 <= 1'b0;
+      _zz_70 <= 1'b0;
+      _zz_72 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_71;
+      IBusCachedPlugin_rspCounter <= _zz_74;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_95 <= 1'b1;
-      execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_106 <= 1'b0;
+      _zz_96 <= 1'b1;
+      _zz_108 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3773,14 +3914,13 @@ module VexRiscv (
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
       CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      _zz_129 <= 32'h0;
+      _zz_128 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
-      _zz_141 <= 3'b000;
-      _zz_142 <= 1'b0;
+      _zz_140 <= 3'b000;
+      _zz_141 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -3804,16 +3944,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+        _zz_70 <= 1'b0;
       end
-      if(_zz_65)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_68)begin
+        _zz_70 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_69 <= 1'b0;
+        _zz_72 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_69 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_72 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3880,19 +4020,8 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_95 <= 1'b0;
-      if(_zz_157)begin
-        if(_zz_176)begin
-          execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
-            execute_LightShifterPlugin_isActive <= 1'b0;
-          end
-        end
-      end
-      if(execute_arbitration_removeIt)begin
-        execute_LightShifterPlugin_isActive <= 1'b0;
-      end
-      _zz_106 <= (_zz_45 && writeBack_arbitration_isFiring);
+      _zz_96 <= 1'b0;
+      _zz_108 <= (_zz_48 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3914,14 +4043,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_177)begin
-        if(_zz_178)begin
+      if(_zz_173)begin
+        if(_zz_174)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_179)begin
+        if(_zz_175)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_180)begin
+        if(_zz_176)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3945,7 +4074,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_163)begin
+      if(_zz_159)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3956,8 +4085,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_164)begin
-        case(_zz_165)
+      if(_zz_160)begin
+        case(_zz_161)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3967,7 +4096,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_120,{_zz_119,_zz_118}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_122,{_zz_121,_zz_120}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(execute_CfuPlugin_schedule)begin
         execute_CfuPlugin_hold <= 1'b1;
       end
@@ -3983,12 +4112,11 @@ module VexRiscv (
       if(memory_CfuPlugin_rsp_ready)begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_181)begin
+      if(_zz_177)begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
       end
-      memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       if((! memory_arbitration_isStuck))begin
-        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_32;
       end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
@@ -4011,29 +4139,29 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_237[0];
-          CsrPlugin_mstatus_MIE <= _zz_238[0];
+          CsrPlugin_mstatus_MPIE <= _zz_234[0];
+          CsrPlugin_mstatus_MIE <= _zz_235[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_240[0];
-          CsrPlugin_mie_MTIE <= _zz_241[0];
-          CsrPlugin_mie_MSIE <= _zz_242[0];
+          CsrPlugin_mie_MEIE <= _zz_237[0];
+          CsrPlugin_mie_MTIE <= _zz_238[0];
+          CsrPlugin_mie_MSIE <= _zz_239[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_129 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_128 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_175)begin
+      if(_zz_172)begin
         if(iBusWishbone_ACK)begin
-          _zz_141 <= (_zz_141 + 3'b001);
+          _zz_140 <= (_zz_140 + 3'b001);
         end
       end
-      _zz_142 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_182)begin
+      _zz_141 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_178)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -4045,7 +4173,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_70 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_73 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -4053,12 +4181,7 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_157)begin
-      if(_zz_176)begin
-        execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
-      end
-    end
-    _zz_107 <= _zz_44[11 : 7];
+    _zz_109 <= _zz_47[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -4074,25 +4197,25 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_162)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_122 ? DBusSimplePlugin_memoryExceptionPort_payload_code : CfuPlugin_joinException_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_122 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : CfuPlugin_joinException_payload_badAddr);
+    if(_zz_158)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_124 ? DBusSimplePlugin_memoryExceptionPort_payload_code : CfuPlugin_joinException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_124 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : CfuPlugin_joinException_payload_badAddr);
     end
-    if(_zz_177)begin
-      if(_zz_178)begin
+    if(_zz_173)begin
+      if(_zz_174)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_179)begin
+      if(_zz_175)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_180)begin
+      if(_zz_176)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_163)begin
+    if(_zz_159)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -4106,27 +4229,16 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_181)begin
+    if(_zz_177)begin
       CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
       CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
-    end
-    if(_zz_156)begin
-      if(_zz_161)begin
-        memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_227,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
-      end
-    end
-    if((! memory_arbitration_isStuck))begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_127 ? (~ _zz_128) : _zz_128) + _zz_234);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_126 ? (~ execute_RS2) : execute_RS2) + _zz_236);
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_39;
+      execute_to_memory_PC <= _zz_42;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
@@ -4144,13 +4256,13 @@ module VexRiscv (
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_56;
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_59;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_57;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_60;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_27;
+      decode_to_execute_SRC1_CTRL <= _zz_29;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -4165,7 +4277,7 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_24;
+      decode_to_execute_SRC2_CTRL <= _zz_26;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -4195,16 +4307,19 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_21;
+      decode_to_execute_ALU_CTRL <= _zz_23;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_18;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_20;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_15;
+      decode_to_execute_SHIFT_CTRL <= _zz_17;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_14;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BRANCH_CTRL <= _zz_12;
@@ -4233,11 +4348,8 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
@@ -4274,17 +4386,38 @@ module VexRiscv (
       execute_to_memory_MMU_RSP2_refilling <= execute_MMU_RSP2_refilling;
       execute_to_memory_MMU_RSP2_bypassTranslation <= execute_MMU_RSP2_bypassTranslation;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_34;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_31;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_39;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_29;
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_31;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -4321,7 +4454,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_239[0];
+        CsrPlugin_mip_MSIP <= _zz_236[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -4336,7 +4469,7 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_182)begin
+    if(_zz_178)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -4390,12 +4523,12 @@ module InstructionCache (
   input               reset
 );
   reg        [31:0]   _zz_9;
-  reg        [24:0]   _zz_10;
+  reg        [22:0]   _zz_10;
   wire                _zz_11;
   wire                _zz_12;
   wire       [0:0]    _zz_13;
   wire       [0:0]    _zz_14;
-  wire       [24:0]   _zz_15;
+  wire       [22:0]   _zz_15;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -4403,7 +4536,7 @@ module InstructionCache (
   (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
-  reg        [4:0]    lineLoader_flushCounter;
+  reg        [6:0]    lineLoader_flushCounter;
   reg                 _zz_3;
   reg                 lineLoader_cmdSent;
   reg                 lineLoader_wayToAllocate_willIncrement;
@@ -4412,23 +4545,23 @@ module InstructionCache (
   wire                lineLoader_wayToAllocate_willOverflow;
   (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
   wire                lineLoader_write_tag_0_valid;
-  wire       [3:0]    lineLoader_write_tag_0_payload_address;
+  wire       [5:0]    lineLoader_write_tag_0_payload_address;
   wire                lineLoader_write_tag_0_payload_data_valid;
   wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [22:0]   lineLoader_write_tag_0_payload_data_address;
+  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
   wire                lineLoader_write_data_0_valid;
-  wire       [6:0]    lineLoader_write_data_0_payload_address;
+  wire       [8:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [6:0]    _zz_4;
+  wire       [8:0]    _zz_4;
   wire                _zz_5;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [3:0]    _zz_6;
+  wire       [5:0]    _zz_6;
   wire                _zz_7;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [22:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [24:0]   _zz_8;
+  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [22:0]   _zz_8;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
@@ -4446,10 +4579,10 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_bypassTranslation;
   reg                 decodeStage_hit_valid;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:127];
-  (* ram_style = "block" *) reg [24:0] ways_0_tags [0:15];
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
-  assign _zz_11 = (! lineLoader_flushCounter[4]);
+  assign _zz_11 = (! lineLoader_flushCounter[6]);
   assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign _zz_13 = _zz_8[0 : 0];
   assign _zz_14 = _zz_8[1 : 1];
@@ -4527,25 +4660,25 @@ module InstructionCache (
   assign lineLoader_wayToAllocate_willClear = 1'b0;
   assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
   assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[4]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[4] ? lineLoader_address[8 : 5] : lineLoader_flushCounter[3 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[4];
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[6]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
   assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 9];
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[8 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[8 : 2];
+  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
   assign _zz_5 = (! io_cpu_fetch_isStuck);
   assign fetchStage_read_banksValue_0_dataMem = _zz_9;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[8 : 5];
+  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
   assign _zz_7 = (! io_cpu_fetch_isStuck);
   assign _zz_8 = _zz_10;
   assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
   assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[24 : 2];
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 9]));
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
@@ -4601,11 +4734,11 @@ module InstructionCache (
       lineLoader_address <= io_cpu_fill_payload;
     end
     if(_zz_11)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 5'h01);
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[4];
+    _zz_3 <= lineLoader_flushCounter[6];
     if(_zz_12)begin
-      lineLoader_flushCounter <= 5'h0;
+      lineLoader_flushCounter <= 7'h0;
     end
     if((! io_cpu_decode_isStuck))begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.yaml
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FomuCfu.yaml
@@ -1,4 +1,4 @@
 iBus: !!vexriscv.BusReport
   flushInstructions: [4111, 19, 19, 19]
-  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 512}
+  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 2048}
   kind: cached

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -255,10 +255,10 @@ object GenCoreDefault{
 
       if(argConfig.mulDiv) {
         if(argConfig.singleCycleMulDiv) {
-          plugins ++= List(
-            new MulPlugin,
-            new DivPlugin
-          )
+          plugins ++= List(new MulPlugin)
+          if (argConfig.hardwareDiv) {
+            plugins ++= List(new DivPlugin)
+          }
         }else {
           plugins ++= List(
             new MulDivIterativePlugin(


### PR DESCRIPTION
This PR makes a series of performance improvements to the Fomu CPU variant. This includes a larger icache (17% reduction in cycle count for inference), a single cycle multiplier (40% reduction in cycle count for inference), and a single cycle shift (16% reduction in cycle count for inference). Previously we didn't have the resources to add these features, but changes in LiteSPI and our LiteX build have afforded us these amenities.